### PR TITLE
Changed 'queued' option shortcut

### DIFF
--- a/src/Console/Make/MakeProjectorCommand.php
+++ b/src/Console/Make/MakeProjectorCommand.php
@@ -51,7 +51,7 @@ class MakeProjectorCommand extends GeneratorCommand
     protected function getOptions()
     {
         return [
-            ['queued', 'q', InputOption::VALUE_NONE, 'Create a QueuedProjector'],
+            ['queued', 'Q', InputOption::VALUE_NONE, 'Create a QueuedProjector'],
         ];
     }
 }

--- a/src/Console/Make/MakeProjectorCommand.php
+++ b/src/Console/Make/MakeProjectorCommand.php
@@ -17,7 +17,7 @@ class MakeProjectorCommand extends GeneratorCommand
     {
         parent::handle();
 
-        if (! $this->option('qeueud')) {
+        if (! $this->option('queued')) {
             return;
         }
 

--- a/src/Console/Make/MakeProjectorCommand.php
+++ b/src/Console/Make/MakeProjectorCommand.php
@@ -17,7 +17,7 @@ class MakeProjectorCommand extends GeneratorCommand
     {
         parent::handle();
 
-        if (! $this->option('sync')) {
+        if (! $this->option('qeueud')) {
             return;
         }
 


### PR DESCRIPTION
`q` is already a shortcut for `--quiet`. Defining it here causes an error: 
```
[2018-06-26 15:09:15] local.ERROR: An option with shortcut "q" already exists. {"exception":"[object] (Symfony\\Component\\Console\\Exception\\LogicException(code: 0): An option with shortcut \"q\" already exists. at D:\\projects\\test\\vendor\\symfony\\console\\Input\\InputDefinition.php:238)
[stacktrace]
#0 D:\\projects\\test\\vendor\\symfony\\console\\Input\\InputDefinition.php(222): Symfony\\Component\\Console\\Input\\InputDefinition->addOption(Object(Symfony\\Component\\Console\\Input\\InputOption))
#1 D:\\projects\\test\\vendor\\symfony\\console\\Command\\Command.php(298): Symfony\\Component\\Console\\Input\\InputDefinition->addOptions(Array)
#2 D:\\projects\\test\\vendor\\symfony\\console\\Descriptor\\TextDescriptor.php(141): Symfony\\Component\\Console\\Command\\Command->mergeApplicationDefinition(false)
#3 D:\\projects\\test\\vendor\\symfony\\console\\Descriptor\\Descriptor.php(52): Symfony\\Component\\Console\\Descriptor\\TextDescriptor->describeCommand(Object(Spatie\\EventProjector\\Console\\Make\\MakeProjectorCommand), Array)
#4 D:\\projects\\test\\vendor\\symfony\\console\\Helper\\DescriptorHelper.php(69): Symfony\\Component\\Console\\Descriptor\\Descriptor->describe(Object(Symfony\\Component\\Console\\Output\\ConsoleOutput), Object(Spatie\\EventProjector\\Console\\Make\\MakeProjectorCommand), Array)
#5 D:\\projects\\test\\vendor\\symfony\\console\\Command\\HelpCommand.php(76): Symfony\\Component\\Console\\Helper\\DescriptorHelper->describe(Object(Symfony\\Component\\Console\\Output\\ConsoleOutput), Object(Spatie\\EventProjector\\Console\\Make\\MakeProjectorCommand), Array)
#6 D:\\projects\\test\\vendor\\symfony\\console\\Command\\Command.php(251): Symfony\\Component\\Console\\Command\\HelpCommand->execute(Object(Symfony\\Component\\Console\\Input\\ArgvInput), Object(Symfony\\Component\\Console\\Output\\ConsoleOutput))
#7 D:\\projects\\test\\vendor\\symfony\\console\\Application.php(886): Symfony\\Component\\Console\\Command\\Command->run(Object(Symfony\\Component\\Console\\Input\\ArgvInput), Object(Symfony\\Component\\Console\\Output\\ConsoleOutput))
#8 D:\\projects\\test\\vendor\\symfony\\console\\Application.php(262): Symfony\\Component\\Console\\Application->doRunCommand(Object(Symfony\\Component\\Console\\Command\\HelpCommand), Object(Symfony\\Component\\Console\\Input\\ArgvInput), Object(Symfony\\Component\\Console\\Output\\ConsoleOutput))
#9 D:\\projects\\test\\vendor\\symfony\\console\\Application.php(145): Symfony\\Component\\Console\\Application->doRun(Object(Symfony\\Component\\Console\\Input\\ArgvInput), Object(Symfony\\Component\\Console\\Output\\ConsoleOutput))
#10 D:\\projects\\test\\vendor\\laravel\\framework\\src\\Illuminate\\Console\\Application.php(89): Symfony\\Component\\Console\\Application->run(Object(Symfony\\Component\\Console\\Input\\ArgvInput), Object(Symfony\\Component\\Console\\Output\\ConsoleOutput))
#11 D:\\projects\\test\\vendor\\laravel\\framework\\src\\Illuminate\\Foundation\\Console\\Kernel.php(122): Illuminate\\Console\\Application->run(Object(Symfony\\Component\\Console\\Input\\ArgvInput), Object(Symfony\\Component\\Console\\Output\\ConsoleOutput))
#12 D:\\projects\\test\\artisan(37): Illuminate\\Foundation\\Console\\Kernel->handle(Object(Symfony\\Component\\Console\\Input\\ArgvInput), Object(Symfony\\Component\\Console\\Output\\ConsoleOutput))
#13 {main}
"} 
```
This also changes the check for `sync` to a check for `qeued` as the `sync` option doesn't exist (and also causes an exception to be thrown)
Tested on an otherwise fresh laravel installation.