### PR TITLE
Allow limited replay

### DIFF
--- a/src/EventProjectionist.php
+++ b/src/EventProjectionist.php
@@ -199,7 +199,7 @@ class EventProjectionist
         return true;
     }
 
-    public function replayEvents(Collection $projectors, int $afterStoredEventId = 0, callable $onEventReplayed = null)
+    public function replayEvents(Collection $projectors, int $afterStoredEventId = 0, int $untilStoredEventId = null, callable $onEventReplayed = null)
     {
         $this->isReplayingEvents = true;
 
@@ -211,6 +211,7 @@ class EventProjectionist
 
         StoredEvent::query()
             ->after($afterStoredEventId ?? 0)
+            ->until($untilStoredEventId)
             ->chunk($this->config['replay_chunk_size'], function (Collection $storedEvents) use ($projectors, $onEventReplayed) {
                 $storedEvents->each(function (StoredEvent $storedEvent) use ($projectors, $onEventReplayed) {
                     $this->callEventHandlers($projectors, $storedEvent);

--- a/src/Models/StoredEvent.php
+++ b/src/Models/StoredEvent.php
@@ -51,6 +51,13 @@ class StoredEvent extends Model
         $query->where('id', '>', $storedEventId);
     }
 
+    public function scopeUntil(Builder $query, int $storedEventId = null)
+    {
+      if ( $storedEventId !== null ) {
+        $query->where('id', '>', $storedEventId);
+      }
+    }
+
     public function getMetaDataAttribute(): SchemalessAttributes
     {
         return SchemalessAttributes::createForModel($this, 'meta_data');


### PR DESCRIPTION
This change allows us to limit event replay up to a specific event ID.

This is useful for reverting the state of an application to any point in time, to the nearest event, and then following the evolution of the application's state step by step.

I've been using a hacky workaround in a little todo app I'm making to learn event sourcing, but once I introduced Reactors it became too complex to manage from outside the library.