### PR TITLE
Add tags to events for Laravel Horizon support

### DIFF
--- a/src/HandleStoredEventJob.php
+++ b/src/HandleStoredEventJob.php
@@ -16,13 +16,28 @@ class HandleStoredEventJob implements ShouldQueue
     /** @var \Spatie\EventProjector\Models\StoredEvent */
     public $storedEvent;
 
-    public function __construct(StoredEvent $storedEvent)
+    /** @var array */
+    public $tags;
+
+    public function __construct(StoredEvent $storedEvent, array $tags)
     {
         $this->storedEvent = $storedEvent;
+        $this->tags = $tags;
     }
 
     public function handle(Projectionist $projectionist)
     {
         $projectionist->handle($this->storedEvent);
+    }
+
+    public function tags(): array
+    {
+        if (empty($this->tags)) {
+            return [
+                $this->storedEvent['event_class'],
+            ];
+        }
+
+        return $this->tags;
     }
 }

--- a/src/Projectionist.php
+++ b/src/Projectionist.php
@@ -100,7 +100,7 @@ class Projectionist
 
         $this->handleImmediately($storedEvent);
 
-        if(method_exists($event, 'tags')) {
+        if (method_exists($event, 'tags')) {
             $tags = $event->tags();
         }
 

--- a/src/Projectionist.php
+++ b/src/Projectionist.php
@@ -100,7 +100,11 @@ class Projectionist
 
         $this->handleImmediately($storedEvent);
 
-        dispatch(new HandleStoredEventJob($storedEvent))
+        if(method_exists($event, 'tags')) {
+            $tags = $event->tags();
+        }
+
+        dispatch(new HandleStoredEventJob($storedEvent, $tags ?? []))
             ->onQueue($this->config['queue']);
     }
 

--- a/tests/TestClasses/Events/MoneyAdded.php
+++ b/tests/TestClasses/Events/MoneyAdded.php
@@ -22,4 +22,12 @@ class MoneyAdded implements ShouldBeStored
 
         $this->amount = $amount;
     }
+
+    public function tags(): array
+    {
+        return [
+            'Account:'. $this->account->id,
+            self::class,
+        ];
+    }
 }


### PR DESCRIPTION
This PR adds support for Laravel Horizon [tags](https://laravel.com/docs/master/horizon#tags).

The docs state that we can add a tags function to any queueable entities and have them show up nicely in Horizon. Because Laravel Event Projector uses it's own `HandleStoredEventJob` which does not handle the user called event tags, currently the tags make little sense (see the screenshot below).

<img width="938" alt="screen shot 2018-08-10 at 23 10 31" src="https://user-images.githubusercontent.com/6132723/43981588-bd0962d0-9cf2-11e8-9273-8c8a4003bbd2.png">

The first entry in this screenshot is an "auto" tag. The second entry is with custom tags set in the `ShouldBeStored` event and the third entry is how the tags looked like before the PR.