### PR TITLE
fix: using StoredEvent model from config in Projectionist

### DIFF
--- a/src/Projectionist.php
+++ b/src/Projectionist.php
@@ -96,7 +96,7 @@ class Projectionist
 
     public function storeEvent(ShouldBeStored $event)
     {
-        $storedEvent = $this->config['stored_event_model']::createForEvent($event);
+        $storedEvent = $this->getStoredEventClass()::createForEvent($event);
 
         $this->handleImmediately($storedEvent);
 
@@ -192,7 +192,7 @@ class Projectionist
 
         $projectors->call('onStartingEventReplay');
 
-        StoredEvent::query()
+        $this->getStoredEventClass()::query()
             ->after($afterStoredEventId ?? 0)
             ->chunk($this->config['replay_chunk_size'], function (Collection $storedEvents) use ($projectors, $onEventReplayed) {
                 $storedEvents->each(function (StoredEvent $storedEvent) use ($projectors, $onEventReplayed) {
@@ -212,5 +212,10 @@ class Projectionist
         event(new FinishedEventReplay());
 
         $projectors->call('onFinishedEventReplay');
+    }
+
+    protected function getStoredEventClass(): string
+    {
+        return config('event-projector.stored_event_model');
     }
 }


### PR DESCRIPTION
In addition to what was updated in [1.0.4](https://github.com/spatie/laravel-event-projector/releases/tag/1.0.4), this PR proposes to also use the `StoredEvent` model from the config in the `Projectionist` class.

Currently, when injecting a custom `StoredEvent` model in a projector, e.g. `App\Events\StoredEventWithMeta $storedEvent` and running the rebuild command, the following error shows up: `Argument 2 passed to (..) must be an instance of App\Events\StoredEventWithMeta, instance of Spatie\EventProjector\Models\StoredEvent given`. With this PR, the correct instance is passed.