### PR TITLE
fix: tests are working again with L5.7

### DIFF
--- a/tests/Console/ListCommandTest.php
+++ b/tests/Console/ListCommandTest.php
@@ -2,6 +2,7 @@
 
 namespace Spatie\EventProjector\Console;
 
+use Illuminate\Support\Facades\Artisan;
 use Spatie\EventProjector\Tests\TestCase;
 use Spatie\EventProjector\Facades\Projectionist;
 use Spatie\EventProjector\Tests\TestClasses\Projectors\BalanceProjector;
@@ -13,16 +14,15 @@ class ListCommandTest extends TestCase
     {
         Projectionist::addProjector(BalanceProjector::class);
 
-        $this->artisan('event-projector:list');
+        Artisan::call('event-projector:list');
 
-        $this
-            ->assertSeeInConsoleOutput(BalanceProjector::class);
+        $this->assertSeeInConsoleOutput(BalanceProjector::class);
     }
 
     /** @test */
     public function it_works_when_no_projectors_are_added_to_the_projectionist()
     {
-        $this->artisan('event-projector:list');
+        Artisan::call('event-projector:list');
 
         $this->assertSeeInConsoleOutput('No projectors found.');
     }

--- a/tests/Console/RebuildCommandTest.php
+++ b/tests/Console/RebuildCommandTest.php
@@ -2,6 +2,7 @@
 
 namespace Spatie\EventProjector\Console\Snapshots;
 
+use Illuminate\Support\Facades\Artisan;
 use Spatie\EventProjector\Tests\TestCase;
 use Spatie\EventProjector\Facades\Projectionist;
 use Spatie\EventProjector\Models\ProjectorStatus;
@@ -28,7 +29,7 @@ class RebuildCommandTest extends TestCase
 
         event(new MoneyAdded($this->account, 1000));
 
-        $this->artisan('event-projector:rebuild', [
+        Artisan::call('event-projector:rebuild', [
             'projector' => [ResettableProjector::class],
         ]);
 
@@ -42,7 +43,7 @@ class RebuildCommandTest extends TestCase
     {
         Projectionist::addProjector(ResettableProjector::class);
 
-        $this->artisan('event-projector:rebuild', [
+        Artisan::call('event-projector:rebuild', [
             'projector' => ['\\'.ResettableProjector::class],
         ]);
 
@@ -58,7 +59,7 @@ class RebuildCommandTest extends TestCase
 
         $this->assertCount(1, ProjectorStatus::get());
 
-        $this->artisan('event-projector:rebuild', [
+        Artisan::call('event-projector:rebuild', [
             'projector' => [ResettableProjector::class],
         ]);
 

--- a/tests/Console/ReplayCommandTest.php
+++ b/tests/Console/ReplayCommandTest.php
@@ -2,6 +2,7 @@
 
 namespace Spatie\EventProjector\Console;
 
+use Illuminate\Support\Facades\Artisan;
 use Mockery;
 use Illuminate\Support\Facades\Mail;
 use Illuminate\Support\Facades\Event;
@@ -73,7 +74,7 @@ class ReplayCommandTest extends TestCase
             return $command;
         });
 
-        $this->artisan('event-projector:replay');
+        Artisan::call('event-projector:replay');
 
         $this->assertSeeInConsoleOutput('No events replayed!');
     }
@@ -94,7 +95,7 @@ class ReplayCommandTest extends TestCase
             return $command;
         });
 
-        $this->artisan('event-projector:replay');
+        Artisan::call('event-projector:replay');
 
         $this->assertSeeInConsoleOutput('Replaying all events...');
     }
@@ -114,7 +115,7 @@ class ReplayCommandTest extends TestCase
 
         Account::create();
 
-        $this->artisan('event-projector:replay', ['projector' => [BalanceProjector::class]]);
+        Artisan::call('event-projector:replay', ['projector' => [BalanceProjector::class]]);
 
         Mail::assertSent(AccountBroke::class, 1);
     }
@@ -126,7 +127,7 @@ class ReplayCommandTest extends TestCase
 
         Projectionist::addProjector($projector);
 
-        $this->artisan('event-projector:replay', [
+        Artisan::call('event-projector:replay', [
             'projector' => [BalanceProjector::class],
         ]);
 
@@ -142,7 +143,7 @@ class ReplayCommandTest extends TestCase
         $projectorStatus->save();
 
         $this->assertEquals(2, $projectorStatus->last_processed_event_id);
-        $this->artisan('event-projector:replay', [
+        Artisan::call('event-projector:replay', [
             'projector' => [BalanceProjector::class],
         ]);
 
@@ -162,7 +163,7 @@ class ReplayCommandTest extends TestCase
         $projector->shouldReceive('onStartingEventReplay')->once();
         $projector->shouldReceive('onFinishedEventReplay')->once();
 
-        $this->artisan('event-projector:replay', [
+        Artisan::call('event-projector:replay', [
             'projector' => [get_class($projector)],
         ]);
     }

--- a/tests/Console/ResetCommandTest.php
+++ b/tests/Console/ResetCommandTest.php
@@ -2,6 +2,7 @@
 
 namespace Spatie\EventProjector\Console\Snapshots;
 
+use Illuminate\Support\Facades\Artisan;
 use Spatie\EventProjector\Tests\TestCase;
 use Spatie\EventProjector\Facades\Projectionist;
 use Spatie\EventProjector\Models\ProjectorStatus;
@@ -17,7 +18,7 @@ class ResetCommandTest extends TestCase
         ProjectorStatus::getForProjector(new ResettableProjector());
         $this->assertCount(1, ProjectorStatus::get());
 
-        $this->artisan('event-projector:reset', [
+        Artisan::call('event-projector:reset', [
             'projector' => [ResettableProjector::class],
         ]);
 


### PR DESCRIPTION
I replaced `$this->artisan()` with `Artisan::call()` in the failing tests. I could not really figure out why 5.7 would make the tests using `$this->artisan()` fail.

Anyhow, all tests are passing again, with backwards compatibility.