### PR TITLE
Add possibility to override the job that handles the stored event

### DIFF
--- a/config/event-projector.php
+++ b/config/event-projector.php
@@ -55,6 +55,11 @@ return [
     'event_serializer' => \Spatie\EventProjector\EventSerializers\JsonEventSerializer::class,
 
     /*
+     * This class is responsible for handling the stored event.
+     */
+    'handle_event_job' => \Spatie\EventProjector\HandleStoredEventJob::class,
+
+    /*
      * When replaying events potentially a lot of events will have to be retrieved.
      * In order to avoid memory problems events will be retrieved in
      * a chuncked way. You can specify the chunk size here.

--- a/src/HandleStoredEventJob.php
+++ b/src/HandleStoredEventJob.php
@@ -11,7 +11,7 @@ use Spatie\EventProjector\Models\StoredEvent;
 
 class HandleStoredEventJob implements ShouldQueue
 {
-    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
+    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels, HandlesStoredEvent;
 
     /** @var \Spatie\EventProjector\Models\StoredEvent */
     public $storedEvent;
@@ -23,21 +23,5 @@ class HandleStoredEventJob implements ShouldQueue
     {
         $this->storedEvent = $storedEvent;
         $this->tags = $tags;
-    }
-
-    public function handle(Projectionist $projectionist)
-    {
-        $projectionist->handle($this->storedEvent);
-    }
-
-    public function tags(): array
-    {
-        if (empty($this->tags)) {
-            return [
-                $this->storedEvent['event_class'],
-            ];
-        }
-
-        return $this->tags;
     }
 }

--- a/src/HandlesStoredEvent.php
+++ b/src/HandlesStoredEvent.php
@@ -1,0 +1,37 @@
+<?php
+
+
+namespace Spatie\EventProjector;
+
+
+/**
+ * Trait HandlesStoredEvent
+ *
+ * @package Spatie\EventProjector
+ */
+trait HandlesStoredEvent
+{
+
+    /**
+     * @param \Spatie\EventProjector\Projectionist $projectionist
+     */
+    public function handle(Projectionist $projectionist)
+    {
+        $projectionist->handle($this->storedEvent);
+    }
+
+    /**
+     * @return array
+     */
+    public function tags(): array
+    {
+        if (empty($this->tags))
+        {
+            return [
+                $this->storedEvent['event_class'],
+            ];
+        }
+
+        return $this->tags;
+    }
+}

--- a/src/Projectionist.php
+++ b/src/Projectionist.php
@@ -107,7 +107,9 @@ class Projectionist
             $tags = $event->tags();
         }
 
-        dispatch(new HandleStoredEventJob($storedEvent, $tags ?? []))
+        $handleStoredEventJob = $this->config['handle_event_job'];
+
+        dispatch(new $handleStoredEventJob($storedEvent, $tags ?? []))
             ->onQueue($this->config['queue']);
     }
 


### PR DESCRIPTION
This pull request adds the ability to use a different class to handle the stored event. 

For a project i'm working on, every job that is handled through the queue needs a specific property set in order to connect to the right database when the job is being handled. This way, i'm able to provide the required information.