### PR TITLE
Lumen support & refactor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ composer.lock
 docs
 vendor
 coverage
+.idea

--- a/config/event-projector.php
+++ b/config/event-projector.php
@@ -48,6 +48,13 @@ return [
     'projector_status_model' => \Spatie\EventProjector\Models\ProjectorStatus::class,
 
     /*
+     * This class is responsible for handle stored events. To add extra behaviour you
+     * can change this to a class of your own. The only restriction is that
+     * it should extend \Spatie\EventProjector\HandleStoredEventJob.
+     */
+    'stored_event_job' => \Spatie\EventProjector\HandleStoredEventJob::class,
+
+    /*
      * This class is responsible for serializing events. By default an event will be serialized
      * and stored as json. You can customize the class name. A valid serializer
      * should implement Spatie\EventProjector\EventSerializers\Serializer.

--- a/src/Console/Concerns/ReplaysEvents.php
+++ b/src/Console/Concerns/ReplaysEvents.php
@@ -48,7 +48,7 @@ trait ReplaysEvents
     {
         $projectorsWithoutStatus = collect($projectors)
             ->filter(function (Projector $projector) {
-                return !$this->getProjectorStatusClass()::query()
+                return ! $this->getProjectorStatusClass()::query()
                     ->where('projector_name', $projector->getName())
                     ->exists();
             });

--- a/src/Console/Concerns/ReplaysEvents.php
+++ b/src/Console/Concerns/ReplaysEvents.php
@@ -3,12 +3,13 @@
 namespace Spatie\EventProjector\Console\Concerns;
 
 use Illuminate\Support\Collection;
-use Illuminate\Support\Facades\DB;
 use Spatie\EventProjector\Projectors\Projector;
-use Spatie\EventProjector\Models\ProjectorStatus;
+use Spatie\EventProjector\Projectors\ProjectsEvents;
 
 trait ReplaysEvents
 {
+    use ProjectsEvents;
+
     public function replay(Collection $projectors)
     {
         $afterEventId = $this->determineAfterEventId($projectors);
@@ -47,7 +48,7 @@ trait ReplaysEvents
     {
         $projectorsWithoutStatus = collect($projectors)
             ->filter(function (Projector $projector) {
-                return ! ProjectorStatus::query()
+                return !$this->getProjectorStatusClass()::query()
                     ->where('projector_name', $projector->getName())
                     ->exists();
             });
@@ -56,11 +57,11 @@ trait ReplaysEvents
             return 0;
         }
 
-        $allProjectorStatusesCount = DB::table('projector_statuses')
+        $allProjectorStatusesCount = $this->getProjectorStatusClass()::query()
             ->whereIn('projector_name', $projectors->map->getName()->toArray())
             ->count();
 
-        $allUpToDateProjectorStatusesCount = DB::table('projector_statuses')
+        $allUpToDateProjectorStatusesCount = $this->getProjectorStatusClass()::query()
             ->whereIn('projector_name', $projectors->map->getName()->toArray())
             ->where('has_received_all_events', true)
             ->count();
@@ -69,7 +70,7 @@ trait ReplaysEvents
             return $this->getStoredEventClass()::getMaxId();
         }
 
-        return DB::table('projector_statuses')
+        return $this->getProjectorStatusClass()::query()
                 ->whereIn('projector_name', $projectors->map->getName()->toArray())
                 ->where('has_received_all_events', false)
                 ->min('last_processed_event_id') ?? 0;

--- a/src/Console/ListCommand.php
+++ b/src/Console/ListCommand.php
@@ -8,9 +8,12 @@ use Illuminate\Support\Collection;
 use Spatie\EventProjector\Projectionist;
 use Spatie\EventProjector\Projectors\Projector;
 use Spatie\EventProjector\Models\ProjectorStatus;
+use Spatie\EventProjector\Projectors\ProjectsEvents;
 
 class ListCommand extends Command
 {
+    use ProjectsEvents;
+
     protected $signature = 'event-projector:list';
 
     protected $description = 'List all event projectors';
@@ -44,7 +47,7 @@ class ListCommand extends Command
     {
         $header = ['Name', 'Last processed event id', 'Stream', 'Last event received at'];
 
-        $rows = ProjectorStatus::query()
+        $rows = $this->getProjectorStatusClass()::query()
             ->where('has_received_all_events', false)
             ->get()
             ->map(function (ProjectorStatus $projectorStatus) {
@@ -87,14 +90,14 @@ class ListCommand extends Command
 
     public function getLastProcessedEventId(Projector $projector): int
     {
-        return ProjectorStatus::query()
+        return $this->getProjectorStatusClass()::query()
                 ->where('projector_name', $projector->getName())
                 ->max('last_processed_event_id') ?? 0;
     }
 
     public function getLastEventProcessedAt(Projector $projector): ?Carbon
     {
-        $status = ProjectorStatus::query()
+        $status = $this->getProjectorStatusClass()::query()
             ->where('projector_name', $projector->getName())
             ->orderBy('updated_at', 'desc')
             ->first();

--- a/src/Console/ReplayCommand.php
+++ b/src/Console/ReplayCommand.php
@@ -4,7 +4,6 @@ namespace Spatie\EventProjector\Console;
 
 use Illuminate\Console\Command;
 use Spatie\EventProjector\Projectionist;
-use Spatie\EventProjector\Projectors\Projector;
 use Spatie\EventProjector\Console\Concerns\ReplaysEvents;
 use Spatie\EventProjector\Console\Concerns\SelectsProjectors;
 
@@ -23,13 +22,13 @@ class ReplayCommand extends Command
     /** @var string */
     protected $storedEventModelClass;
 
-    public function __construct(Projectionist $projectionist, string $storedEventModelClass)
+    public function __construct(Projectionist $projectionist)
     {
         parent::__construct();
 
         $this->projectionist = $projectionist;
 
-        $this->storedEventModelClass = $storedEventModelClass;
+        $this->storedEventModelClass = $this->getStoredEventClass();
     }
 
     public function handle()

--- a/src/HandleStoredEventJob.php
+++ b/src/HandleStoredEventJob.php
@@ -6,12 +6,11 @@ use Illuminate\Bus\Queueable;
 use Illuminate\Queue\SerializesModels;
 use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Contracts\Queue\ShouldQueue;
-use Illuminate\Foundation\Bus\Dispatchable;
 use Spatie\EventProjector\Models\StoredEvent;
 
 class HandleStoredEventJob implements ShouldQueue
 {
-    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
+    use InteractsWithQueue, Queueable, SerializesModels;
 
     /** @var \Spatie\EventProjector\Models\StoredEvent */
     public $storedEvent;
@@ -39,5 +38,10 @@ class HandleStoredEventJob implements ShouldQueue
         }
 
         return $this->tags;
+    }
+
+    public static function createForEvent(StoredEvent $event, array $tags)
+    {
+        return new static($event, $tags);
     }
 }

--- a/src/Models/StoredEvent.php
+++ b/src/Models/StoredEvent.php
@@ -3,13 +3,13 @@
 namespace Spatie\EventProjector\Models;
 
 use Exception;
+use Carbon\Carbon;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Builder;
 use Spatie\EventProjector\ShouldBeStored;
 use Spatie\SchemalessAttributes\SchemalessAttributes;
 use Spatie\EventProjector\Exceptions\InvalidStoredEvent;
 use Spatie\EventProjector\EventSerializers\EventSerializer;
-use Carbon\Carbon;
 
 class StoredEvent extends Model
 {

--- a/src/Models/StoredEvent.php
+++ b/src/Models/StoredEvent.php
@@ -3,13 +3,13 @@
 namespace Spatie\EventProjector\Models;
 
 use Exception;
-use Illuminate\Support\Facades\DB;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Builder;
 use Spatie\EventProjector\ShouldBeStored;
 use Spatie\SchemalessAttributes\SchemalessAttributes;
 use Spatie\EventProjector\Exceptions\InvalidStoredEvent;
 use Spatie\EventProjector\EventSerializers\EventSerializer;
+use Carbon\Carbon;
 
 class StoredEvent extends Model
 {
@@ -28,7 +28,7 @@ class StoredEvent extends Model
         $storedEvent->event_class = get_class($event);
         $storedEvent->attributes['event_properties'] = app(EventSerializer::class)->serialize(clone $event);
         $storedEvent->meta_data = [];
-        $storedEvent->created_at = now();
+        $storedEvent->created_at = Carbon::now();
 
         $storedEvent->save();
 
@@ -37,7 +37,7 @@ class StoredEvent extends Model
 
     public static function getMaxId(): int
     {
-        return DB::table((new static())->getTable())->max('id') ?? 0;
+        return static::query()->max('id') ?? 0;
     }
 
     public function getEventAttribute(): ShouldBeStored

--- a/src/Projectionist.php
+++ b/src/Projectionist.php
@@ -107,8 +107,9 @@ class Projectionist
             $tags = $event->tags();
         }
 
-        dispatch(new HandleStoredEventJob($storedEvent, $tags ?? []))
-            ->onQueue($this->config['queue']);
+        $storedEventJob = $this->getStoredEventJob()::createForEvent($storedEvent, $tags ?? []);
+
+        dispatch($storedEventJob->onQueue($this->config['queue']));
     }
 
     public function handle(StoredEvent $storedEvent)
@@ -233,5 +234,10 @@ class Projectionist
     protected function getStoredEventClass(): string
     {
         return config('event-projector.stored_event_model');
+    }
+
+    protected function getStoredEventJob(): string
+    {
+        return config('event-projector.stored_event_job');
     }
 }


### PR DESCRIPTION
1. Added supoort for Lumen framework
2. Added ```stored_event_job``` config option. You can redefine ```HandleStoredEventJob``` class.
3. Fixed bad usage of ```ProjectorStatus``` model. Removed any hardcode of table name, query builder, etc.
4. Added ```.idea``` to .gitignore