### PR TITLE
allow overriding queue name

### DIFF
--- a/src/Models/StoredEvent.php
+++ b/src/Models/StoredEvent.php
@@ -92,7 +92,7 @@ class StoredEvent extends Model
                     $tags ?? []
                 );
 
-                dispatch($storedEventJob->onQueue(config('event-projector.queue')));
+                dispatch($storedEventJob->onQueue($event->queue ?? config('event-projector.queue')));
             });
     }
 

--- a/tests/EventSubscriberTest.php
+++ b/tests/EventSubscriberTest.php
@@ -3,20 +3,20 @@
 namespace Spatie\EventProjector\Tests;
 
 use Illuminate\Support\Facades\Bus;
-use Illuminate\Support\Facades\Queue;
 use Illuminate\Support\Facades\Mail;
+use Illuminate\Support\Facades\Queue;
 use Spatie\EventProjector\Models\StoredEvent;
 use Spatie\EventProjector\HandleStoredEventJob;
 use Spatie\EventProjector\Facades\Projectionist;
 use Spatie\EventProjector\Tests\TestClasses\Models\Account;
 use Spatie\EventProjector\Tests\TestClasses\Reactors\BrokeReactor;
 use Spatie\EventProjector\Tests\TestClasses\Events\MoneyAddedEvent;
-use Spatie\EventProjector\Tests\TestClasses\Events\MoneyAddedEventWithQueueOverride;
 use Spatie\EventProjector\Tests\TestClasses\Mailables\AccountBroke;
 use Spatie\EventProjector\Tests\TestClasses\Events\DoNotStoreThisEvent;
 use Spatie\EventProjector\Tests\TestClasses\Projectors\QueuedProjector;
 use Spatie\EventProjector\Tests\TestClasses\Events\MoneySubtractedEvent;
 use Spatie\EventProjector\Tests\TestClasses\Projectors\BalanceProjector;
+use Spatie\EventProjector\Tests\TestClasses\Events\MoneyAddedEventWithQueueOverride;
 use Spatie\EventProjector\Tests\TestClasses\Projectors\ProjectorThatInvokesAnObject;
 
 final class EventSubscriberTest extends TestCase
@@ -131,7 +131,7 @@ final class EventSubscriberTest extends TestCase
     public function event_without_queue_override_will_be_queued_correctly()
     {
         Queue::fake();
-        
+
         $this->setConfig('event-projector.queue', 'defaultQueue');
 
         $projector = new QueuedProjector();
@@ -146,7 +146,7 @@ final class EventSubscriberTest extends TestCase
     public function event_with_queue_override_will_be_queued_correctly()
     {
         Queue::fake();
-        
+
         $this->setConfig('event-projector.queue', 'defaultQueue');
 
         $projector = new QueuedProjector();

--- a/tests/TestClasses/Events/MoneyAddedEventWithQueueOverride.php
+++ b/tests/TestClasses/Events/MoneyAddedEventWithQueueOverride.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Spatie\EventProjector\Tests\TestClasses\Events;
+
+use Illuminate\Queue\SerializesModels;
+use Spatie\EventProjector\ShouldBeStored;
+use Spatie\EventProjector\Tests\TestClasses\Models\Account;
+
+final class MoneyAddedEventWithQueueOverride implements ShouldBeStored
+{
+    use SerializesModels;
+
+    /** @var \Spatie\EventProjector\Tests\TestClasses\Models\Account */
+    public $account;
+
+    /** @var int */
+    public $amount;
+
+    /** @var string */
+    public $queue = "testQueue";
+
+    public function __construct(Account $account, int $amount)
+    {
+        $this->account = $account;
+
+        $this->amount = $amount;
+    }
+
+    public function tags(): array
+    {
+        return [
+            'Account:'.$this->account->id,
+            self::class,
+        ];
+    }
+}

--- a/tests/TestClasses/Events/MoneyAddedEventWithQueueOverride.php
+++ b/tests/TestClasses/Events/MoneyAddedEventWithQueueOverride.php
@@ -17,7 +17,7 @@ final class MoneyAddedEventWithQueueOverride implements ShouldBeStored
     public $amount;
 
     /** @var string */
-    public $queue = "testQueue";
+    public $queue = 'testQueue';
 
     public function __construct(Account $account, int $amount)
     {

--- a/tests/TestClasses/Projectors/BalanceProjector.php
+++ b/tests/TestClasses/Projectors/BalanceProjector.php
@@ -15,7 +15,7 @@ class BalanceProjector implements Projector
     protected $handlesEvents = [
         MoneyAddedEvent::class => 'onMoneyAdded',
         MoneySubtractedEvent::class => 'onMoneySubtracted',
-        MoneyAddedEventWithQueueOverride::class => 'onMoneyAdded'
+        MoneyAddedEventWithQueueOverride::class => 'onMoneyAdded',
     ];
 
     public function onMoneyAdded(MoneyAddedEvent $event)

--- a/tests/TestClasses/Projectors/BalanceProjector.php
+++ b/tests/TestClasses/Projectors/BalanceProjector.php
@@ -6,6 +6,7 @@ use Spatie\EventProjector\Projectors\Projector;
 use Spatie\EventProjector\Projectors\ProjectsEvents;
 use Spatie\EventProjector\Tests\TestClasses\Events\MoneyAddedEvent;
 use Spatie\EventProjector\Tests\TestClasses\Events\MoneySubtractedEvent;
+use Spatie\EventProjector\Tests\TestClasses\Events\MoneyAddedEventWithQueueOverride;
 
 class BalanceProjector implements Projector
 {
@@ -14,6 +15,7 @@ class BalanceProjector implements Projector
     protected $handlesEvents = [
         MoneyAddedEvent::class => 'onMoneyAdded',
         MoneySubtractedEvent::class => 'onMoneySubtracted',
+        MoneyAddedEventWithQueueOverride::class => 'onMoneyAdded'
     ];
 
     public function onMoneyAdded(MoneyAddedEvent $event)


### PR DESCRIPTION
Hopefully this seems like a good idea.  Allow defining queue name in events.  My specific use case is segregating low priority event processing into a separate queue, like imports, but this could also be handy to segregate event processing by domain.