### PR TITLE
Specify stored event model for aggregates.

### DIFF
--- a/src/AggregateRoot.php
+++ b/src/AggregateRoot.php
@@ -34,12 +34,17 @@ abstract class AggregateRoot
     public function persist(): AggregateRoot
     {
         call_user_func(
-            [$this->storedEventModel ?? config('event-projector.stored_event_model'), 'storeMany'],
+            [$this->getStoredEventClass(), 'storeMany'],
             $this->getAndClearRecoredEvents(),
             $this->aggregateUuid
         );
 
         return $this;
+    }
+
+    protected function getStoredEventClass(): string
+    {
+        return $this->storedEventModel ?? config('event-projector.stored_event_model');
     }
 
     private function getAndClearRecoredEvents(): array

--- a/src/AggregateRoot.php
+++ b/src/AggregateRoot.php
@@ -58,7 +58,7 @@ abstract class AggregateRoot
 
     private function reconstituteFromEvents(): AggregateRoot
     {
-        StoredEvent::uuid($this->aggregateUuid)->each(function (StoredEvent $storedEvent) {
+        $this->getStoredEventModel()::uuid($this->aggregateUuid)->each(function (StoredEvent $storedEvent) {
             $this->apply($storedEvent->event);
         });
 

--- a/src/AggregateRoot.php
+++ b/src/AggregateRoot.php
@@ -34,7 +34,7 @@ abstract class AggregateRoot
     public function persist(): AggregateRoot
     {
         call_user_func(
-            [config('event-projector.stored_event_model'), 'storeMany'],
+            [$this->storedEventModel ?? config('event-projector.stored_event_model'), 'storeMany'],
             $this->getAndClearRecoredEvents(),
             $this->aggregateUuid
         );

--- a/src/AggregateRoot.php
+++ b/src/AggregateRoot.php
@@ -34,7 +34,7 @@ abstract class AggregateRoot
     public function persist(): AggregateRoot
     {
         call_user_func(
-            [$this->getStoredEventClass(), 'storeMany'],
+            [$this->getStoredEventModel(), 'storeMany'],
             $this->getAndClearRecoredEvents(),
             $this->aggregateUuid
         );
@@ -42,7 +42,7 @@ abstract class AggregateRoot
         return $this;
     }
 
-    protected function getStoredEventClass(): string
+    protected function getStoredEventModel(): string
     {
         return $this->storedEventModel ?? config('event-projector.stored_event_model');
     }

--- a/src/Projectors/ProjectsEvents.php
+++ b/src/Projectors/ProjectsEvents.php
@@ -27,9 +27,4 @@ trait ProjectsEvents
     {
         return ! $this instanceof QueuedProjector;
     }
-
-    protected function getStoredEventClass(): string
-    {
-        return $this->storedEventModel ?? config('event-projector.stored_event_model');
-    }
 }

--- a/src/Projectors/ProjectsEvents.php
+++ b/src/Projectors/ProjectsEvents.php
@@ -30,6 +30,6 @@ trait ProjectsEvents
 
     protected function getStoredEventClass(): string
     {
-        return config('event-projector.stored_event_model');
+        return $this->storedEventModel ?? config('event-projector.stored_event_model');
     }
 }

--- a/tests/AggregateRootTest.php
+++ b/tests/AggregateRootTest.php
@@ -85,6 +85,29 @@ final class AggregateRootTest extends TestCase
     }
 
     /** @test */
+    public function when_retrieving_an_aggregate_root_all_events_will_be_replayed_to_it_with_the_stored_event_model_specified()
+    {
+        /** @var \Spatie\EventProjector\Tests\TestClasses\AggregateRoots\AccountAggregateRootWithStoredEventSpecified $aggregateRoot */
+        $aggregateRoot = AccountAggregateRootWithStoredEventSpecified::retrieve($this->aggregateUuid);
+
+        $aggregateRoot
+            ->addMoney(100)
+            ->addMoney(100)
+            ->addMoney(100);
+
+        $aggregateRoot->persist();
+
+        $this->assertEquals(0, StoredEvent::count());
+        $this->assertEquals(3, OtherStoredEvent::count());
+
+        $aggregateRoot = AccountAggregateRoot::retrieve($this->aggregateUuid);
+        $this->assertEquals(0, $aggregateRoot->balance);
+
+        $aggregateRoot = AccountAggregateRootWithStoredEventSpecified::retrieve($this->aggregateUuid);
+        $this->assertEquals(300, $aggregateRoot->balance);
+    }
+
+    /** @test */
     public function a_recorded_event_immediately_gets_applied()
     {
         $aggregateRoot = AccountAggregateRoot::retrieve($this->aggregateUuid);

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -2,6 +2,7 @@
 
 namespace Spatie\EventProjector\Tests;
 
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
 use Illuminate\Support\Facades\Artisan;
 use Illuminate\Database\Schema\Blueprint;
@@ -45,6 +46,9 @@ abstract class TestCase extends Orchestra
         Schema::dropIfExists('stored_events');
         include_once __DIR__.'/../stubs/create_stored_events_table.php.stub';
         (new \CreateStoredEventsTable())->up();
+
+        Schema::dropIfExists('other_stored_events');
+        DB::statement('CREATE TABLE other_stored_events LIKE stored_events');
     }
 
     protected function assertSeeInConsoleOutput(string $text): self

--- a/tests/TestClasses/AggregateRoots/AccountAggregateRootWithStoredEventSpecified.php
+++ b/tests/TestClasses/AggregateRoots/AccountAggregateRootWithStoredEventSpecified.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Spatie\EventProjector\Tests\TestClasses\AggregateRoots;
+
+use Spatie\EventProjector\AggregateRoot;
+use Spatie\EventProjector\Tests\TestClasses\Models\OtherStoredEvent;
+use Spatie\EventProjector\Tests\TestClasses\AggregateRoots\StorableEvents\MoneyAdded;
+
+final class AccountAggregateRootWithStoredEventSpecified extends AggregateRoot
+{
+    public $balance = 0;
+    public $storedEventModel = OtherStoredEvent::class;
+
+    public function addMoney(int $amount): self
+    {
+        $this->recordThat(new MoneyAdded($amount));
+
+        return $this;
+    }
+
+    public function applyMoneyAdded(MoneyAdded $event)
+    {
+        $this->balance += $event->amount;
+    }
+}

--- a/tests/TestClasses/Models/OtherStoredEvent.php
+++ b/tests/TestClasses/Models/OtherStoredEvent.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Spatie\EventProjector\Tests\TestClasses\Models;
+
+use Spatie\EventProjector\Models\StoredEvent as BaseStoredEvent;
+
+class OtherStoredEvent extends BaseStoredEvent
+{
+    /**
+     * The table associated with the model.
+     *
+     * @var string
+     */
+    protected $table = 'other_stored_events';
+}


### PR DESCRIPTION
I have a multi-tenant application, so I need stored events for the main application, and stored events for each customer database. I need to be able to specify which stored event model to persist the aggregate's events to.

Also during this, I noticed `\Spatie\EventProjector\Projectors\ProjectsEvents@getStoredEventClass` is not used. I removed that method.