### PR TITLE
Disabling discovery break the artisan.

### DIFF
--- a/src/DiscoverEventHandlers.php
+++ b/src/DiscoverEventHandlers.php
@@ -53,6 +53,10 @@ final class DiscoverEventHandlers
 
     public function addToProjectionist(Projectionist $projectionist)
     {
+        if (empty($this->directories)) {
+            return;
+        }
+
         $files = (new Finder())->files()->in($this->directories);
 
         return collect($files)


### PR DESCRIPTION
I follow the doc to disable auto discover projector & reactor feature (set `auto_discover_projectors_and_reactors` to an empty array), then execute `php artisan migrate:fresh` and get the error:
```
In Finder.php line 602:

  You must call one of in() or append() methods before iterating over a Finde
  r.
```

When `Symfony\Component\Finder`'s property `$dirs` is empty, `collect($files)` will throw an exception, so I think the easy solution is that don't execute the rest of code when there is no discovery path.