### PR TITLE
Fix inconsistent variable/method name in stub

### DIFF
--- a/stubs/projector.stub
+++ b/stubs/projector.stub
@@ -9,7 +9,7 @@ final class DummyClass implements Projector
 {
     use ProjectsEvents;
 
-    public function onEventHappened(EventHappended $event)
+    public function onEventHappened(EventHappened $event)
     {
     }
 }

--- a/stubs/reactor.stub
+++ b/stubs/reactor.stub
@@ -9,7 +9,7 @@ final class DummyClass implements EventHandler
 {
     use HandlesEvents;
 
-    public function onEventHappened(EventHappended $event)
+    public function onEventHappened(EventHappened $event)
     {
     }
 }


### PR DESCRIPTION
Changes `Happended` (extra `d`) => `Happened` 

~If you wouldn't mind squashing these commits together, I made these edits on the GitHub website and committed them separately.~

Edit: Squashed the commits together. 😄 