### PR TITLE
Actually warn when no projector/reactor is registered

### DIFF
--- a/src/Console/ListCommand.php
+++ b/src/Console/ListCommand.php
@@ -20,14 +20,14 @@ final class ListCommand extends Command
         $rows = $this->convertEventHandlersToTableRows($projectors);
         count($rows)
             ? $this->table(['Event', 'Handled by projectors'], $rows)
-            : 'No projectors registered';
+            : $this->warn('No projectors registered');
 
         $this->info('');
         $projectors = $projectionist->getReactors();
         $rows = $this->convertEventHandlersToTableRows($projectors);
         count($rows)
             ? $this->table(['Event', 'Handled by reactors'], $rows)
-            : 'No reactors registered';
+            : $this->warn('No reactors registered');
     }
 
     private function convertEventHandlersToTableRows(Collection $eventHandlers): array


### PR DESCRIPTION
I was investigating why none of my events were actually taken into account, and noticed that the `event-project:list` command didn't actually output anything.

It seems like the intent of whoever wrote that command was to warn the user, stating that no reactor/projector was found, but the actual `$this->warn(...)` was forgotten.

This PR simply adds them, so that debugging is a little bit easier.