### PR TITLE
let the aggregateRoot retrieve events to a specific storedEventId.

### DIFF
--- a/src/AggregateRoot.php
+++ b/src/AggregateRoot.php
@@ -35,7 +35,7 @@ abstract class AggregateRoot
     {
         call_user_func(
             [$this->getStoredEventModel(), 'storeMany'],
-            $this->getAndClearRecoredEvents(),
+            $this->getAndClearRecordedEvents(),
             $this->aggregateUuid
         );
 
@@ -47,7 +47,7 @@ abstract class AggregateRoot
         return $this->storedEventModel ?? config('event-projector.stored_event_model');
     }
 
-    private function getAndClearRecoredEvents(): array
+    private function getAndClearRecordedEvents(): array
     {
         $recordedEvents = $this->recordedEvents;
 

--- a/src/Models/StoredEvent.php
+++ b/src/Models/StoredEvent.php
@@ -56,6 +56,15 @@ class StoredEvent extends Model
         $query->where('id', '>=', $storedEventId);
     }
 
+    public function scopeEndingTo(Builder $query, ?int $storedEventId)
+    {
+        if ($storedEventId === null) {
+            return $query;
+        }
+
+        return $query->where('id', '<=', $storedEventId);
+    }
+
     public function scopeUuid(Builder $query, string $uuid): void
     {
         $query->where('aggregate_uuid', $uuid);

--- a/tests/AggregateRootTest.php
+++ b/tests/AggregateRootTest.php
@@ -160,4 +160,22 @@ final class AggregateRootTest extends TestCase
             return true;
         });
     }
+
+    /** @test */
+    public function when_retrieving_an_aggregate_root_with_a_specific_event_will_be_replayed_just_to_it()
+    {
+        /** @var \Spatie\EventProjector\Tests\TestClasses\AggregateRoots\AccountAggregateRoot $aggregateRoot */
+        $aggregateRoot = AccountAggregateRoot::retrieve($this->aggregateUuid);
+
+        $aggregateRoot
+            ->addMoney(100)
+            ->addMoney(200)
+            ->addMoney(300);
+
+        $aggregateRoot->persist();
+
+        $aggregateRoot = AccountAggregateRoot::retrieve($this->aggregateUuid, 2);
+
+        $this->assertEquals(300, $aggregateRoot->balance);
+    }
 }

--- a/tests/Models/StoredEventTest.php
+++ b/tests/Models/StoredEventTest.php
@@ -33,6 +33,14 @@ final class StoredEventTest extends TestCase
     }
 
     /** @test */
+    public function it_has_a_scope_to_get_all_events_ending_to_given_id()
+    {
+        $this->fireEvents(4);
+
+        $this->assertEquals([1, 2], StoredEvent::endingTo(2)->pluck('id')->toArray());
+    }
+
+    /** @test */
     public function it_will_throw_a_human_readable_exception_when_the_event_couldnt_be_deserialized()
     {
         $this->fireEvents();


### PR DESCRIPTION
When debugging, we often want to know how the current state become, so if we can retrieving to a eventId then we can debug step by step.