### PR TITLE
Replay command now uses stored event class argument

### DIFF
--- a/src/Console/ReplayCommand.php
+++ b/src/Console/ReplayCommand.php
@@ -85,7 +85,7 @@ class ReplayCommand extends Command
             $bar->advance();
         };
 
-        $this->projectionist->replay($projectors, $startingFrom, $onEventReplayed);
+        $this->projectionist->replay($this->getStoredEventClass(), $projectors, $startingFrom, $onEventReplayed);
 
         $bar->finish();
 

--- a/src/Projectionist.php
+++ b/src/Projectionist.php
@@ -29,9 +29,6 @@ final class Projectionist
     /** @var bool */
     private $replayChunkSize;
 
-    /** @var string */
-    private $storedEventClass;
-
     /** @var bool */
     private $isProjecting = false;
 
@@ -45,7 +42,6 @@ final class Projectionist
 
         $this->catchExceptions = $config['catch_exceptions'];
         $this->replayChunkSize = $config['replay_chunk_size'];
-        $this->storedEventClass = $config['stored_event_model'];
     }
 
     public function addProjector($projector): Projectionist
@@ -248,6 +244,7 @@ final class Projectionist
     }
 
     public function replay(
+        string $storedEventClass,
         Collection $projectors,
         int $startingFromEventId = 0,
         callable $onEventReplayed = null
@@ -268,7 +265,7 @@ final class Projectionist
 
         $projectors->call('onStartingEventReplay');
 
-        $this->storedEventClass::query()
+        $storedEventClass::query()
             ->startingFrom($startingFromEventId ?? 0)
             ->chunk($this->replayChunkSize, function (Collection $storedEvents) use ($projectors, $onEventReplayed) {
                 $storedEvents->each(function (StoredEvent $storedEvent) use ($projectors, $onEventReplayed) {


### PR DESCRIPTION
So, in my PR earlier this year we added the argument `--stored-event-model` but my I missed the changes to  Projectionist to actually make use of the argument . Oops 🙈  Fixed it now.