### PR TITLE
Only allow public projector methods to be auto detected

### DIFF
--- a/src/EventHandlers/HandlesEvents.php
+++ b/src/EventHandlers/HandlesEvents.php
@@ -73,6 +73,9 @@ trait HandlesEvents
         return collect((new ReflectionClass($this))->getMethods())
             ->flatMap(function (ReflectionMethod $method) {
                 $method = new ReflectionMethod($this, $method->name);
+                if (! $method->isPublic()) {
+                    return;
+                }
 
                 $eventClass = collect($method->getParameters())
                     ->map(function (ReflectionParameter $parameter) {

--- a/tests/TestClasses/Projectors/ProjectorWithoutHandlesEvents.php
+++ b/tests/TestClasses/Projectors/ProjectorWithoutHandlesEvents.php
@@ -29,4 +29,12 @@ class ProjectorWithoutHandlesEvents implements Projector
     public function functionWithUnreleatedClassTypeHint(Collection $test)
     {
     }
+
+    protected function protectedFunction(MoneyAddedEvent $event)
+    {
+    }
+
+    private function privateFunction(MoneyAddedEvent $event)
+    {
+    }
 }


### PR DESCRIPTION
When you write a projector with a protected and or private method that uses an event, the projector will fail to handle an event thrown at it with the error: `call_user_func_array() expects parameter 1 to be a valid callback, cannot access protected method`.

It is fixed with my PR. This will only search for public methods in the projector and ignore internally used methods.