### PR TITLE
Ensure eloquent stored events are retrieved in order of ID.

### DIFF
--- a/src/EloquentStoredEventRepository.php
+++ b/src/EloquentStoredEventRepository.php
@@ -21,7 +21,7 @@ class EloquentStoredEventRepository implements StoredEventRepository
             $query->uuid($uuid);
         }
 
-        return $query->cursor()->map(function (EloquentStoredEvent $storedEvent) {
+        return $query->orderBy('id')->cursor()->map(function (EloquentStoredEvent $storedEvent) {
             return $storedEvent->toStoredEvent();
         });
     }
@@ -35,7 +35,7 @@ class EloquentStoredEventRepository implements StoredEventRepository
             $query->uuid($uuid);
         }
 
-        return $query->cursor()->map(function (EloquentStoredEvent $storedEvent) {
+        return $query->orderBy('id')->cursor()->map(function (EloquentStoredEvent $storedEvent) {
             return $storedEvent->toStoredEvent();
         });
     }

--- a/tests/AggregateRootTest.php
+++ b/tests/AggregateRootTest.php
@@ -85,6 +85,23 @@ final class AggregateRootTest extends TestCase
     }
 
     /** @test */
+    public function when_retrieving_an_aggregate_root_all_events_will_be_replayed_to_it_in_the_correct_order()
+    {
+        /** @var \Spatie\EventProjector\Tests\TestClasses\AggregateRoots\AccountAggregateRoot $aggregateRoot */
+        $aggregateRoot = AccountAggregateRoot::retrieve($this->aggregateUuid);
+
+        $aggregateRoot
+            ->multiplyMoney(5)
+            ->addMoney(100);
+
+        $aggregateRoot->persist();
+
+        $aggregateRoot = AccountAggregateRoot::retrieve($this->aggregateUuid);
+
+        $this->assertEquals(100, $aggregateRoot->balance);
+    }
+
+    /** @test */
     public function when_retrieving_an_aggregate_root_all_events_will_be_replayed_to_it_with_the_stored_event_repository_specified()
     {
         /** @var \Spatie\EventProjector\Tests\TestClasses\AggregateRoots\AccountAggregateRootWithStoredEventRepositorySpecified $aggregateRoot */

--- a/tests/EventSerializers/EventSerializerTest.php
+++ b/tests/EventSerializers/EventSerializerTest.php
@@ -59,14 +59,12 @@ final class EventSerializerTest extends TestCase
 
         $array = json_decode($json, true);
 
-        $connection = config('database.default');
-        $driver = config("database.connections.{$connection}.driver");
         $this->assertEquals([
             'account' => [
                 'class' => get_class($account),
                 'id' => 1,
                 'relations' => [],
-                'connection' => $driver,
+                'connection' => $this->dbDriver(),
             ],
             'amount' => 1234,
         ], $array);

--- a/tests/EventSerializers/EventSerializerTest.php
+++ b/tests/EventSerializers/EventSerializerTest.php
@@ -59,7 +59,6 @@ final class EventSerializerTest extends TestCase
 
         $array = json_decode($json, true);
 
-
         $connection = config('database.default');
         $driver = config("database.connections.{$connection}.driver");
         $this->assertEquals([

--- a/tests/EventSerializers/EventSerializerTest.php
+++ b/tests/EventSerializers/EventSerializerTest.php
@@ -59,12 +59,15 @@ final class EventSerializerTest extends TestCase
 
         $array = json_decode($json, true);
 
+
+        $connection = config('database.default');
+        $driver = config("database.connections.{$connection}.driver");
         $this->assertEquals([
             'account' => [
                 'class' => get_class($account),
                 'id' => 1,
                 'relations' => [],
-                'connection' => 'mysql',
+                'connection' => $driver,
             ],
             'amount' => 1234,
         ], $array);

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -54,7 +54,9 @@ abstract class TestCase extends Orchestra
         } elseif ($this->dbDriver() === 'pgsql') {
             DB::statement('CREATE TABLE other_stored_events AS TABLE stored_events;');
         } else {
-            throw new Exception("DB driver [$driver] is not supported by this test suite.");
+            throw new Exception(
+                sprintf('DB driver [%s] is not supported by this test suite.', $this->dbDriver())
+            );
         }
     }
 

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -48,12 +48,10 @@ abstract class TestCase extends Orchestra
         include_once __DIR__.'/../stubs/create_stored_events_table.php.stub';
         (new \CreateStoredEventsTable())->up();
 
-        $connection = config('database.default');
-        $driver = config("database.connections.{$connection}.driver");
         Schema::dropIfExists('other_stored_events');
-        if ($driver === 'mysql') {
+        if ($this->dbDriver() === 'mysql') {
             DB::statement('CREATE TABLE other_stored_events LIKE stored_events');
-        } elseif ($driver === 'pgsql') {
+        } elseif ($this->dbDriver() === 'pgsql') {
             DB::statement('CREATE TABLE other_stored_events AS TABLE stored_events;');
         } else {
             throw new Exception("DB driver [$driver] is not supported by this test suite.");
@@ -76,5 +74,12 @@ abstract class TestCase extends Orchestra
     protected function pathToTests(): string
     {
         return __DIR__;
+    }
+
+    protected function dbDriver(): string
+    {
+        $connection = config('database.default');
+
+        return config("database.connections.{$connection}.driver");
     }
 }

--- a/tests/TestClasses/AggregateRoots/AccountAggregateRoot.php
+++ b/tests/TestClasses/AggregateRoots/AccountAggregateRoot.php
@@ -4,6 +4,7 @@ namespace Spatie\EventProjector\Tests\TestClasses\AggregateRoots;
 
 use Spatie\EventProjector\AggregateRoot;
 use Spatie\EventProjector\Tests\TestClasses\AggregateRoots\StorableEvents\MoneyAdded;
+use Spatie\EventProjector\Tests\TestClasses\AggregateRoots\StorableEvents\MoneyMultiplied;
 
 final class AccountAggregateRoot extends AggregateRoot
 {
@@ -16,8 +17,20 @@ final class AccountAggregateRoot extends AggregateRoot
         return $this;
     }
 
+    public function multiplyMoney(int $amount): self
+    {
+        $this->recordThat(new MoneyMultiplied($amount));
+
+        return $this;
+    }
+
     public function applyMoneyAdded(MoneyAdded $event)
     {
         $this->balance += $event->amount;
+    }
+
+    public function applyMoneyMultiplied(MoneyMultiplied $event)
+    {
+        $this->balance *= $event->amount;
     }
 }

--- a/tests/TestClasses/AggregateRoots/StorableEvents/MoneyMultiplied.php
+++ b/tests/TestClasses/AggregateRoots/StorableEvents/MoneyMultiplied.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Spatie\EventProjector\Tests\TestClasses\AggregateRoots\StorableEvents;
+
+use Spatie\EventProjector\ShouldBeStored;
+
+final class MoneyMultiplied implements ShouldBeStored
+{
+    /** @var int */
+    public $amount;
+
+    public function __construct(int $amount)
+    {
+        $this->amount = $amount;
+    }
+}


### PR DESCRIPTION
I have an app with a postgres database. Records don't return in order of insert for me so my apps tests were failing. This PR does two things:

* So that the aggregate has events applied in the correct order, the query will be ordered by id.
* Supports the `pgsql` driver for this test suite.