### PR TITLE
Re-introduce the stored_event_model config

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -12,9 +12,6 @@ Because there are many breaking changes we cannot give you a waterproof list of 
 
 ## From v2 to v3
 
-- Remove the `stored_event_model` key in your `event-projector.php` config file
 - Add a `stored_event_repository` config key with the following value: `\Spatie\EventProjector\EloquentStoredEventRepository::class`
 - If you're using a different model for event storage:
-    1. The `\Spatie\EventProjector\Models\StoredEvent::class` has been renamed to `\Spatie\EventProjector\Models\EloquentStoredEvent::class`
-    2. Extend the `\Spatie\EventProjector\EloquentStoredEventRepository` and change the `$storedEventModel` property with your own model that extends `\Spatie\EventProjector\Models\EloquentStoredEvent`
-    3. Change the `stored_event_repository` config value with your own repository
+    1. Make sure the model extends `\Spatie\EventProjector\Models\EloquentStoredEvent`

--- a/config/event-projector.php
+++ b/config/event-projector.php
@@ -42,6 +42,13 @@ return [
     'catch_exceptions' => env('EVENT_PROJECTOR_CATCH_EXCEPTIONS', false),
 
     /*
+     * This class is responsible for storing events in the ELoquentStoredEventRepository.
+     * To add extra behaviour you can change this to a class of your own. It should
+     * extend the \Spatie\EventProjector\Models\EloquentStoredEvent model.
+     */
+    'stored_event_model' => \Spatie\EventProjector\Models\EloquentStoredEvent::class,
+
+    /*
      * This class is responsible for storing events. To add extra behaviour you
      * can change this to a class of your own. The only restriction is that
      * it should implement \Spatie\EventProjector\StoredEventRepository.

--- a/docs/advanced-usage/storing-metadata.md
+++ b/docs/advanced-usage/storing-metadata.md
@@ -9,16 +9,7 @@ You can add metadata, such as the `id` of the logged in user, to a stored event.
 
 If you need to store metadata on all events you can leverage Laravel's native models events when using the `EloquentStoredEventRepository`.
 
-You must configure the package to [use your own event storage repository](/laravel-event-projector/v3/advanced-usage/using-your-own-event-storage-repository) that extends the `EloquentStoredEventRepository` with a custom Eloquent model. On that model you can hook into the model lifecycle hooks.
-
-```php
-use Spatie\EventProjector\EloquentStoredEventRepository;
-
-class CustomStoredEventRepository extends EloquentStoredEventRepository
-{
-    protected $storedEventModel = \App\CustomStoredEvent::class;
-}
-```
+You must configure the package to [use your own eloquent event storage model](/laravel-event-projector/v3/advanced-usage/using-your-own-event-storage-model) that extends the `EloquentStoredEvent` model. On that model you can hook into the model lifecycle hooks.
 
 ```php
 use Spatie\EventProjector\Models\EloquentStoredEvent;

--- a/docs/advanced-usage/using-aliases-for-stored-event-classes.md
+++ b/docs/advanced-usage/using-aliases-for-stored-event-classes.md
@@ -1,6 +1,6 @@
 ---
 title: Using aliases for stored event classes
-weight: 8
+weight: 9
 ---
 
 By default we store the `Event`'s FQCN in the database when storing the events. This prevents you from changing the name or the namespace of your event classes.

--- a/docs/advanced-usage/using-your-own-event-serializer.md
+++ b/docs/advanced-usage/using-your-own-event-serializer.md
@@ -1,6 +1,6 @@
 ---
 title: Using your own event serializer
-weight: 7
+weight: 8
 ---
 
 Events will be serialized by the `Spatie\EventProjector\EventSerializers\JsonEventSerializer`. Like the name implies, this class can serialize an event to json so it can be easily stored in a `json` column in the database.

--- a/docs/advanced-usage/using-your-own-event-storage-model.md
+++ b/docs/advanced-usage/using-your-own-event-storage-model.md
@@ -1,0 +1,6 @@
+---
+title: Using your own event storage repository
+weight: 6
+---
+
+The default model responsible for storing events is `\Spatie\EventProjector\Models\EloquentStoredEvent`. If you want to add behaviour to that model you can create a class of your own that extends the `EloquentStoredEvent` model. You should put the class name of your model in the `stored_event_model` in the `event-projector.php` config file.

--- a/docs/advanced-usage/using-your-own-event-storage-repository.md
+++ b/docs/advanced-usage/using-your-own-event-storage-repository.md
@@ -1,12 +1,6 @@
 ---
 title: Using your own event storage repository
-weight: 6
+weight: 7
 ---
 
 The default repository responsible for storing events is `\Spatie\EventProjector\EloquentStoredEventRepository`. If you want to use a different storage method, implement the `\Spatie\EventProjector\StoredEventRepository` repository and add your custom functionality.
-
-If you just want to use a different model for the Eloquent storage:
-
-1. Create your own Eloquent model and extend the `\Spatie\EventProjector\Models\EloquentStoredEvent::class` class
-2. Extend the `\Spatie\EventProjector\EloquentStoredEventRepository` and change the `$storedEventModel` property with your own model that extends `\Spatie\EventProjector\Models\EloquentStoredEvent`
-3. Change the `stored_event_repository` config value with your own repository in the `event-projector.php` config file.

--- a/src/AggregateRoot.php
+++ b/src/AggregateRoot.php
@@ -4,7 +4,6 @@ namespace Spatie\EventProjector;
 
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
-use Spatie\EventProjector\Models\StoredEvent;
 
 abstract class AggregateRoot
 {

--- a/src/EloquentStoredEventRepository.php
+++ b/src/EloquentStoredEventRepository.php
@@ -4,9 +4,8 @@ namespace Spatie\EventProjector;
 
 use Carbon\Carbon;
 use Illuminate\Support\LazyCollection;
-use Spatie\EventProjector\Models\StoredEvent;
-use Spatie\EventProjector\Models\EloquentStoredEvent;
 use Spatie\EventProjector\EventSerializers\EventSerializer;
+use Spatie\EventProjector\Models\EloquentStoredEvent;
 
 class EloquentStoredEventRepository implements StoredEventRepository
 {

--- a/src/EloquentStoredEventRepository.php
+++ b/src/EloquentStoredEventRepository.php
@@ -4,9 +4,9 @@ namespace Spatie\EventProjector;
 
 use Carbon\Carbon;
 use Illuminate\Support\LazyCollection;
+use Spatie\EventProjector\Models\EloquentStoredEvent;
 use Spatie\EventProjector\EventSerializers\EventSerializer;
 use Spatie\EventProjector\Exceptions\InvalidEloquentStoredEventModel;
-use Spatie\EventProjector\Models\EloquentStoredEvent;
 
 class EloquentStoredEventRepository implements StoredEventRepository
 {

--- a/src/EloquentStoredEventRepository.php
+++ b/src/EloquentStoredEventRepository.php
@@ -5,11 +5,21 @@ namespace Spatie\EventProjector;
 use Carbon\Carbon;
 use Illuminate\Support\LazyCollection;
 use Spatie\EventProjector\EventSerializers\EventSerializer;
+use Spatie\EventProjector\Exceptions\InvalidEloquentStoredEventModel;
 use Spatie\EventProjector\Models\EloquentStoredEvent;
 
 class EloquentStoredEventRepository implements StoredEventRepository
 {
-    protected $storedEventModel = EloquentStoredEvent::class;
+    protected $storedEventModel;
+
+    public function __construct()
+    {
+        $this->storedEventModel = config('event-projector.stored_event_model', EloquentStoredEvent::class);
+
+        if (! new $this->storedEventModel instanceof EloquentStoredEvent) {
+            throw new InvalidEloquentStoredEventModel("The class {$this->storedEventModel} must extend EloquentStoredEvent");
+        }
+    }
 
     public function retrieveAll(string $uuid = null): LazyCollection
     {

--- a/src/EventHandlers/EventHandler.php
+++ b/src/EventHandlers/EventHandler.php
@@ -4,7 +4,7 @@ namespace Spatie\EventProjector\EventHandlers;
 
 use Exception;
 use Illuminate\Support\Collection;
-use Spatie\EventProjector\Models\StoredEvent;
+use Spatie\EventProjector\StoredEvent;
 
 interface EventHandler
 {

--- a/src/EventHandlers/EventHandlerCollection.php
+++ b/src/EventHandlers/EventHandlerCollection.php
@@ -3,7 +3,7 @@
 namespace Spatie\EventProjector\EventHandlers;
 
 use Illuminate\Support\Collection;
-use Spatie\EventProjector\Models\StoredEvent;
+use Spatie\EventProjector\StoredEvent;
 
 final class EventHandlerCollection
 {

--- a/src/EventHandlers/HandlesEvents.php
+++ b/src/EventHandlers/HandlesEvents.php
@@ -3,13 +3,13 @@
 namespace Spatie\EventProjector\EventHandlers;
 
 use Exception;
+use Illuminate\Support\Collection;
 use ReflectionClass;
 use ReflectionMethod;
 use ReflectionParameter;
-use Illuminate\Support\Collection;
-use Spatie\EventProjector\ShouldBeStored;
-use Spatie\EventProjector\Models\StoredEvent;
 use Spatie\EventProjector\Exceptions\InvalidEventHandler;
+use Spatie\EventProjector\ShouldBeStored;
+use Spatie\EventProjector\StoredEvent;
 
 trait HandlesEvents
 {

--- a/src/EventHandlers/HandlesEvents.php
+++ b/src/EventHandlers/HandlesEvents.php
@@ -3,13 +3,13 @@
 namespace Spatie\EventProjector\EventHandlers;
 
 use Exception;
-use Illuminate\Support\Collection;
 use ReflectionClass;
 use ReflectionMethod;
 use ReflectionParameter;
-use Spatie\EventProjector\Exceptions\InvalidEventHandler;
-use Spatie\EventProjector\ShouldBeStored;
+use Illuminate\Support\Collection;
 use Spatie\EventProjector\StoredEvent;
+use Spatie\EventProjector\ShouldBeStored;
+use Spatie\EventProjector\Exceptions\InvalidEventHandler;
 
 trait HandlesEvents
 {

--- a/src/Events/EventHandlerFailedHandlingEvent.php
+++ b/src/Events/EventHandlerFailedHandlingEvent.php
@@ -3,8 +3,8 @@
 namespace Spatie\EventProjector\Events;
 
 use Exception;
-use Spatie\EventProjector\EventHandlers\EventHandler;
 use Spatie\EventProjector\StoredEvent;
+use Spatie\EventProjector\EventHandlers\EventHandler;
 
 final class EventHandlerFailedHandlingEvent
 {

--- a/src/Events/EventHandlerFailedHandlingEvent.php
+++ b/src/Events/EventHandlerFailedHandlingEvent.php
@@ -3,8 +3,8 @@
 namespace Spatie\EventProjector\Events;
 
 use Exception;
-use Spatie\EventProjector\Models\StoredEvent;
 use Spatie\EventProjector\EventHandlers\EventHandler;
+use Spatie\EventProjector\StoredEvent;
 
 final class EventHandlerFailedHandlingEvent
 {

--- a/src/Exceptions/InvalidEloquentStoredEventModel.php
+++ b/src/Exceptions/InvalidEloquentStoredEventModel.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Spatie\EventProjector\Exceptions;
+
+use Exception;
+use Spatie\EventProjector\StoredEvent;
+
+final class InvalidEloquentStoredEventModel extends Exception
+{
+}

--- a/src/Exceptions/InvalidEloquentStoredEventModel.php
+++ b/src/Exceptions/InvalidEloquentStoredEventModel.php
@@ -3,7 +3,6 @@
 namespace Spatie\EventProjector\Exceptions;
 
 use Exception;
-use Spatie\EventProjector\StoredEvent;
 
 final class InvalidEloquentStoredEventModel extends Exception
 {

--- a/src/Exceptions/InvalidStoredEvent.php
+++ b/src/Exceptions/InvalidStoredEvent.php
@@ -3,7 +3,7 @@
 namespace Spatie\EventProjector\Exceptions;
 
 use Exception;
-use Spatie\EventProjector\Models\StoredEvent;
+use Spatie\EventProjector\StoredEvent;
 
 final class InvalidStoredEvent extends Exception
 {

--- a/src/HandleStoredEventJob.php
+++ b/src/HandleStoredEventJob.php
@@ -3,9 +3,9 @@
 namespace Spatie\EventProjector;
 
 use Illuminate\Bus\Queueable;
-use Illuminate\Contracts\Queue\ShouldQueue;
-use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Queue\SerializesModels;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Contracts\Queue\ShouldQueue;
 
 final class HandleStoredEventJob implements ShouldQueue
 {

--- a/src/HandleStoredEventJob.php
+++ b/src/HandleStoredEventJob.php
@@ -3,16 +3,15 @@
 namespace Spatie\EventProjector;
 
 use Illuminate\Bus\Queueable;
-use Illuminate\Queue\SerializesModels;
-use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Contracts\Queue\ShouldQueue;
-use Spatie\EventProjector\Models\StoredEvent;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
 
 final class HandleStoredEventJob implements ShouldQueue
 {
     use InteractsWithQueue, Queueable, SerializesModels;
 
-    /** @var \Spatie\EventProjector\Models\StoredEvent */
+    /** @var \Spatie\EventProjector\StoredEvent */
     public $storedEvent;
 
     /** @var array */

--- a/src/Models/EloquentStoredEvent.php
+++ b/src/Models/EloquentStoredEvent.php
@@ -2,9 +2,10 @@
 
 namespace Spatie\EventProjector\Models;
 
-use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
 use Spatie\EventProjector\ShouldBeStored;
+use Spatie\EventProjector\StoredEvent;
 
 class EloquentStoredEvent extends Model
 {

--- a/src/Models/EloquentStoredEvent.php
+++ b/src/Models/EloquentStoredEvent.php
@@ -2,10 +2,10 @@
 
 namespace Spatie\EventProjector\Models;
 
-use Illuminate\Database\Eloquent\Builder;
-use Illuminate\Database\Eloquent\Model;
-use Spatie\EventProjector\ShouldBeStored;
 use Spatie\EventProjector\StoredEvent;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Builder;
+use Spatie\EventProjector\ShouldBeStored;
 
 class EloquentStoredEvent extends Model
 {

--- a/src/Projectionist.php
+++ b/src/Projectionist.php
@@ -5,14 +5,14 @@ namespace Spatie\EventProjector;
 use Exception;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
+use Spatie\EventProjector\Projectors\Projector;
 use Spatie\EventProjector\EventHandlers\EventHandler;
-use Spatie\EventProjector\EventHandlers\EventHandlerCollection;
-use Spatie\EventProjector\Events\EventHandlerFailedHandlingEvent;
 use Spatie\EventProjector\Events\FinishedEventReplay;
 use Spatie\EventProjector\Events\StartingEventReplay;
-use Spatie\EventProjector\Exceptions\InvalidEventHandler;
-use Spatie\EventProjector\Projectors\Projector;
 use Spatie\EventProjector\Projectors\QueuedProjector;
+use Spatie\EventProjector\Exceptions\InvalidEventHandler;
+use Spatie\EventProjector\EventHandlers\EventHandlerCollection;
+use Spatie\EventProjector\Events\EventHandlerFailedHandlingEvent;
 
 final class Projectionist
 {

--- a/src/Projectionist.php
+++ b/src/Projectionist.php
@@ -5,15 +5,14 @@ namespace Spatie\EventProjector;
 use Exception;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
-use Spatie\EventProjector\Models\StoredEvent;
-use Spatie\EventProjector\Projectors\Projector;
 use Spatie\EventProjector\EventHandlers\EventHandler;
-use Spatie\EventProjector\Events\FinishedEventReplay;
-use Spatie\EventProjector\Events\StartingEventReplay;
-use Spatie\EventProjector\Projectors\QueuedProjector;
-use Spatie\EventProjector\Exceptions\InvalidEventHandler;
 use Spatie\EventProjector\EventHandlers\EventHandlerCollection;
 use Spatie\EventProjector\Events\EventHandlerFailedHandlingEvent;
+use Spatie\EventProjector\Events\FinishedEventReplay;
+use Spatie\EventProjector\Events\StartingEventReplay;
+use Spatie\EventProjector\Exceptions\InvalidEventHandler;
+use Spatie\EventProjector\Projectors\Projector;
+use Spatie\EventProjector\Projectors\QueuedProjector;
 
 final class Projectionist
 {

--- a/src/StoredEvent.php
+++ b/src/StoredEvent.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Spatie\EventProjector\Models;
+namespace Spatie\EventProjector;
 
 use Exception;
 use Illuminate\Support\Arr;

--- a/src/StoredEventRepository.php
+++ b/src/StoredEventRepository.php
@@ -3,7 +3,6 @@
 namespace Spatie\EventProjector;
 
 use Illuminate\Support\LazyCollection;
-use Spatie\EventProjector\Models\StoredEvent;
 
 interface StoredEventRepository
 {

--- a/tests/AggregateRootTest.php
+++ b/tests/AggregateRootTest.php
@@ -3,13 +3,13 @@
 namespace Spatie\EventProjector\Tests;
 
 use Illuminate\Support\Facades\Mail;
-use Spatie\EventProjector\Exceptions\InvalidEloquentStoredEventModel;
 use Spatie\EventProjector\Facades\Projectionist;
 use Spatie\EventProjector\Models\EloquentStoredEvent;
 use Spatie\EventProjector\Tests\TestClasses\FakeUuid;
 use Spatie\EventProjector\Tests\TestClasses\Models\Account;
-use Spatie\EventProjector\Tests\TestClasses\Models\InvalidEloquentStoredEvent;
+use Spatie\EventProjector\Exceptions\InvalidEloquentStoredEventModel;
 use Spatie\EventProjector\Tests\TestClasses\Models\OtherEloquentStoredEvent;
+use Spatie\EventProjector\Tests\TestClasses\Models\InvalidEloquentStoredEvent;
 use Spatie\EventProjector\Tests\TestClasses\AggregateRoots\AccountAggregateRoot;
 use Spatie\EventProjector\Tests\TestClasses\AggregateRoots\Reactors\SendMailReactor;
 use Spatie\EventProjector\Tests\TestClasses\AggregateRoots\StorableEvents\MoneyAdded;

--- a/tests/AggregateRootTest.php
+++ b/tests/AggregateRootTest.php
@@ -3,10 +3,12 @@
 namespace Spatie\EventProjector\Tests;
 
 use Illuminate\Support\Facades\Mail;
+use Spatie\EventProjector\Exceptions\InvalidEloquentStoredEventModel;
 use Spatie\EventProjector\Facades\Projectionist;
 use Spatie\EventProjector\Models\EloquentStoredEvent;
 use Spatie\EventProjector\Tests\TestClasses\FakeUuid;
 use Spatie\EventProjector\Tests\TestClasses\Models\Account;
+use Spatie\EventProjector\Tests\TestClasses\Models\InvalidEloquentStoredEvent;
 use Spatie\EventProjector\Tests\TestClasses\Models\OtherEloquentStoredEvent;
 use Spatie\EventProjector\Tests\TestClasses\AggregateRoots\AccountAggregateRoot;
 use Spatie\EventProjector\Tests\TestClasses\AggregateRoots\Reactors\SendMailReactor;
@@ -64,6 +66,41 @@ final class AggregateRootTest extends TestCase
         $event = $storedEvent->event;
         $this->assertInstanceOf(MoneyAdded::class, $event);
         $this->assertEquals(100, $event->amount);
+    }
+
+    /** @test */
+    public function when_an_the_config_specifies_a_stored_event_model_persisting_will_persist_all_events_it_recorded_via_stored_event()
+    {
+        config()->set('event-projector.stored_event_model', OtherEloquentStoredEvent::class);
+
+        AccountAggregateRoot::retrieve($this->aggregateUuid)
+            ->addMoney(100)
+            ->persist();
+
+        $storedEvents = EloquentStoredEvent::get();
+        $this->assertCount(0, $storedEvents);
+
+        $otherStoredEvents = OtherEloquentStoredEvent::get();
+        $this->assertCount(1, $otherStoredEvents);
+
+        $storedEvent = $otherStoredEvents->first();
+        $this->assertEquals($this->aggregateUuid, $storedEvent->aggregate_uuid);
+
+        $event = $storedEvent->event;
+        $this->assertInstanceOf(MoneyAdded::class, $event);
+        $this->assertEquals(100, $event->amount);
+    }
+
+    /** @test * */
+    public function it_throws_an_error_when_defining_a_class_that_doesnt_extend_eloquent_stored_event()
+    {
+        config()->set('event-projector.stored_event_model', InvalidEloquentStoredEvent::class);
+
+        $this->expectException(InvalidEloquentStoredEventModel::class);
+
+        AccountAggregateRoot::retrieve($this->aggregateUuid)
+            ->addMoney(100)
+            ->persist();
     }
 
     /** @test */

--- a/tests/TestClasses/Models/InvalidEloquentStoredEvent.php
+++ b/tests/TestClasses/Models/InvalidEloquentStoredEvent.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Spatie\EventProjector\Tests\TestClasses\Models;
+
+class InvalidEloquentStoredEvent
+{
+    /**
+     * The table associated with the model.
+     *
+     * @var string
+     */
+    protected $table = 'other_stored_events';
+}

--- a/tests/TestClasses/Projectors/ProjectorThatWritesMetaData.php
+++ b/tests/TestClasses/Projectors/ProjectorThatWritesMetaData.php
@@ -2,10 +2,10 @@
 
 namespace Spatie\EventProjector\Tests\TestClasses\Projectors;
 
-use Spatie\EventProjector\Projectors\Projector;
-use Spatie\EventProjector\Projectors\ProjectsEvents;
 use Spatie\EventProjector\StoredEvent;
+use Spatie\EventProjector\Projectors\Projector;
 use Spatie\EventProjector\StoredEventRepository;
+use Spatie\EventProjector\Projectors\ProjectsEvents;
 use Spatie\EventProjector\Tests\TestClasses\Events\MoneyAddedEvent;
 
 final class ProjectorThatWritesMetaData implements Projector

--- a/tests/TestClasses/Projectors/ProjectorThatWritesMetaData.php
+++ b/tests/TestClasses/Projectors/ProjectorThatWritesMetaData.php
@@ -2,10 +2,10 @@
 
 namespace Spatie\EventProjector\Tests\TestClasses\Projectors;
 
-use Spatie\EventProjector\Models\StoredEvent;
 use Spatie\EventProjector\Projectors\Projector;
-use Spatie\EventProjector\StoredEventRepository;
 use Spatie\EventProjector\Projectors\ProjectsEvents;
+use Spatie\EventProjector\StoredEvent;
+use Spatie\EventProjector\StoredEventRepository;
 use Spatie\EventProjector\Tests\TestClasses\Events\MoneyAddedEvent;
 
 final class ProjectorThatWritesMetaData implements Projector

--- a/tests/TestClasses/Repositories/OtherEloquentStoredEventRepository.php
+++ b/tests/TestClasses/Repositories/OtherEloquentStoredEventRepository.php
@@ -3,7 +3,6 @@
 namespace Spatie\EventProjector\Tests\TestClasses\Repositories;
 
 use Spatie\EventProjector\EloquentStoredEventRepository;
-use Spatie\EventProjector\Models\EloquentStoredEvent;
 use Spatie\EventProjector\Tests\TestClasses\Models\OtherEloquentStoredEvent;
 
 class OtherEloquentStoredEventRepository extends EloquentStoredEventRepository

--- a/tests/TestClasses/Repositories/OtherEloquentStoredEventRepository.php
+++ b/tests/TestClasses/Repositories/OtherEloquentStoredEventRepository.php
@@ -3,9 +3,15 @@
 namespace Spatie\EventProjector\Tests\TestClasses\Repositories;
 
 use Spatie\EventProjector\EloquentStoredEventRepository;
+use Spatie\EventProjector\Models\EloquentStoredEvent;
 use Spatie\EventProjector\Tests\TestClasses\Models\OtherEloquentStoredEvent;
 
 class OtherEloquentStoredEventRepository extends EloquentStoredEventRepository
 {
-    protected $storedEventModel = OtherEloquentStoredEvent::class;
+    protected $storedEventModel;
+
+    public function __construct()
+    {
+        $this->storedEventModel = OtherEloquentStoredEvent::class;
+    }
 }


### PR DESCRIPTION
- Makes it easier to upgrade
- Makes it easier if you just want to use a different model
- Will do nothing if you use a different repository

I've also moved the `StoredEvent` class out of the `models` folder to avoid confusion, as this is just a DTO and not an actual Laravel Model