### PR TITLE
Docs: Adding and Removing Projectors and Reactors

### DIFF
--- a/docs/advanced-usage/adding-and-removing-projectors-and-reactors.md
+++ b/docs/advanced-usage/adding-and-removing-projectors-and-reactors.md
@@ -1,0 +1,61 @@
+---
+title: Adding and Removing Projectors and Reactors
+weight: 10
+---
+
+You can add and remove projectors and reactors via the `Projectionist` facade.
+
+Whilst this package can auto-discover your event handlers, it is still useful to be able to add and remove projectors for your test suite. For example, a slow reactor might be worth removing to speed up your tests if the behaviour of that reactor is not relevant for the feature you are testing.
+
+## Adding Projectors
+
+Adding one projector:
+
+```php
+Projectionist::addProjector(TransactionCountProjector::class);
+```
+
+Adding many projectors:
+
+```php
+Projectionist::addProjector([
+    AccountBalanceProjector::class,
+    TransactionCountProjector::class,
+]);
+```
+
+## Adding Reactors
+
+Adding one reactor:
+
+```php
+Projectionist::addReactor(SendMailReactor::class);
+```
+
+Adding many reactors:
+
+```php
+Projectionist::addReactor([
+    SendMailReactor::class,
+    SendPushNotificationReactor::class,
+]);
+```
+
+## Removing Projectors and Reactors
+
+A projector and a reactor are both event handlers. You can remove either of them with the same function.
+
+Removing one event handler:
+
+```php
+Projectionist::withoutEventHandler(SendPushNotificationReactor::class);
+```
+
+Removing many event handlers:
+
+```php
+Projectionist::withoutEventHandlers([
+    TransactionCountProjector::class,
+    SendPushNotificationReactor::class,
+]);
+```

--- a/docs/advanced-usage/adding-and-removing-projectors-and-reactors.md
+++ b/docs/advanced-usage/adding-and-removing-projectors-and-reactors.md
@@ -5,7 +5,7 @@ weight: 10
 
 You can add and remove projectors and reactors via the `Projectionist` facade.
 
-Whilst this package can auto-discover your event handlers, it is still useful to be able to add and remove projectors for your test suite. For example, a slow reactor might be worth removing to speed up your tests if the behaviour of that reactor is not relevant for the feature you are testing.
+Whilst this package can auto-discover your event handlers, it is still useful to be able to add and remove projectors or reactors for your test suite. For example, a slow reactor might be worth removing to speed up your tests if the behaviour of that reactor is not relevant for the feature you are testing.
 
 ## Adding Projectors
 

--- a/docs/advanced-usage/discovering-projectors-and-reactors.md
+++ b/docs/advanced-usage/discovering-projectors-and-reactors.md
@@ -3,7 +3,7 @@ title: Discovering projectors and reactors
 weight: 5
 ---
 
-By default the package will automatically discover all projectors and reactors and will register them at the projectionist. 
+By default the package will automatically discover all projectors and reactors and will register them at the projectionist.
 
 If you want to see a list of the discovered projectors and reactors perform the `event-projector:list` Artisan command. Here's how the output could look like:
 
@@ -13,6 +13,6 @@ If you want to see a list of the discovered projectors and reactors perform the 
 
 In production, you likely do not want the package to scan all of your classes on every request. Therefore, during your deployment process, you should run the `event-projector:cache-event-handlers` Artisan command to cache a manifest of all of your application's projectors and reactors. This manifest will be used by the package to speed up the registration process. The `event-projector:clear-event-handlers` command may be used to destroy the cache.
 
-## Disabling disovery
+## Disabling discovery
 
-If you want to turn off autodiscovery and want to enforce manualy registration of projectors and reactors, just set the `auto_discover_projectors_and_reactors` key in the `event-projector` config file to an empty array.
+If you want to turn off auto-discovery and want to enforce manually registration of projectors and reactors, just set the `auto_discover_projectors_and_reactors` key in the `event-projector` config file to an empty array.

--- a/docs/advanced-usage/preparing-events.md
+++ b/docs/advanced-usage/preparing-events.md
@@ -41,7 +41,7 @@ If your event has an eloquent model, it should also use the `Illuminate\Queue\Se
 
 ## Specifying a queue
 
-When a `StoredEvent` is created, we'll dispatch a job on the queue defined in the `queue` key of the `event-projector` config file. Queued projectors and reactors will get called when the job is executed on the queue. 
+When a `StoredEvent` is created, we'll dispatch a job on the queue defined in the `queue` key of the `event-projector` config file. Queued projectors and reactors will get called when the job is executed on the queue.
 
 On an event you can override the queue that should be used by adding a `queue` property.
 

--- a/docs/advanced-usage/replaying-events.md
+++ b/docs/advanced-usage/replaying-events.md
@@ -24,8 +24,8 @@ All [events](/laravel-event-projector/v2/advanced-usage/preparing-events/) that 
   ```bash
    php artisan event-projector:replay --projector=App\\Projectors\\AccountBalanceProjector --projector=App\\Projectors\\AnotherProjector
   ```
-  
-If your projector has a `resetState` method it will get called before replaying events. You can use that method to reset the state of your projector. 
+
+If your projector has a `resetState` method it will get called before replaying events. You can use that method to reset the state of your projector.
 
 If you want to replay events starting from a certain event you can use the `--from` option when executing `event-projector:replay`. If you use this option the `resetState` on projectors will not get called. This package does not track which events have already been processed by which projectors. Be sure not to replay events to projectors that already have handled them.
 
@@ -77,7 +77,7 @@ After all events are replayed, the `onFinishedEventReplay` method will be called
 
 ## Models with timestamps
 
-When using models with timestamps, it is important to keep in mind that the projector will create or update these models when replaying and the timestamps will not correspond to the event's original timestamps. This will probably not be behavior you intended. To work around this you can use the stored event's timestamps:
+When using models with timestamps, it is important to keep in mind that the projector will create or update these models when replaying and the timestamps will not correspond to the event's original timestamps. This will probably not be behaviour you intended. To work around this you can use the stored event's timestamps:
 
 ```php
 public function onAccountCreated(StoredEvent $storedEvent, AccountCreated $event) {
@@ -87,4 +87,4 @@ public function onAccountCreated(StoredEvent $storedEvent, AccountCreated $event
 
 ## What about reactors?
 
-Reactors are used to handle side effects, like sending mails and such. You'll only want reactors to do their work when an event is originally fired. You don't want to send out mails when replaying events. That's why reactors will never get called when replaying events.  
+Reactors are used to handle side effects, like sending mails and such. You'll only want reactors to do their work when an event is originally fired. You don't want to send out mails when replaying events. That's why reactors will never get called when replaying events.

--- a/docs/advanced-usage/replaying-events.md
+++ b/docs/advanced-usage/replaying-events.md
@@ -3,11 +3,11 @@ title: Replaying events
 weight: 2
 ---
 
-All [events](/laravel-event-projector/v2/advanced-usage/preparing-events/) that implement `Spatie\EventProjector\ShouldBeStored` will be [serialized](https://docs.spatie.be/laravel-event-projector/v2/advanced-usage/using-your-own-event-serializer) and stored in the `stored_events` table. After your app has been doing its work for a while the `stored_events` table will probably contain some events.
+All [events](/laravel-event-projector/v3/advanced-usage/preparing-events/) that implement `Spatie\EventProjector\ShouldBeStored` will be [serialized](/laravel-event-projector/v3/advanced-usage/using-your-own-event-serializer) and stored in the `stored_events` table. After your app has been doing its work for a while the `stored_events` table will probably contain some events.
 
- When creating a new [projector](/laravel-event-projector/v2/using-projectors/writing-your-first-projector/) or [reactor](/laravel-event-projector/v2/using-reactors/writing-your-first-reactor/) you'll want to feed all stored events to that new projector or reactor. We call this process replaying events.
+ When creating a new [projector](/laravel-event-projector/v3/using-projectors/writing-your-first-projector/) or [reactor](/laravel-event-projector/v3/using-reactors/writing-your-first-reactor/) you'll want to feed all stored events to that new projector or reactor. We call this process replaying events.
 
- Events can be replayed to [all projectors that were added to the projectionist](/laravel-event-projector/v2/using-projectors/creating-and-configuring-projectors/) with this artisan command:
+ Events can be replayed to [all projectors that were added to the projectionist](/laravel-event-projector/v3/using-projectors/creating-and-configuring-projectors/) with this artisan command:
 
  ```bash
  php artisan event-projector:replay
@@ -29,7 +29,7 @@ If your projector has a `resetState` method it will get called before replaying 
 
 If you want to replay events starting from a certain event you can use the `--from` option when executing `event-projector:replay`. If you use this option the `resetState` on projectors will not get called. This package does not track which events have already been processed by which projectors. Be sure not to replay events to projectors that already have handled them.
 
-If you are [using your own event storage model](/laravel-event-projector/v2/advanced-usage/using-your-own-event-storage-model/) then you will need to use the `--store-event-model` option when executing `event-projector:replay` to specify the model storing the events you want to replay.
+If you are [using your own event storage model](/laravel-event-projector/v3/advanced-usage/using-your-own-event-storage-model/) then you will need to use the `--store-event-model` option when executing `event-projector:replay` to specify the model storing the events you want to replay.
 
 ```bash
 php artisan event-projector:replay --stored-event-model=App\\Models\\AccountStoredEvent

--- a/docs/advanced-usage/using-aliases-for-stored-event-classes.md
+++ b/docs/advanced-usage/using-aliases-for-stored-event-classes.md
@@ -18,4 +18,4 @@ To get around this you can define event class aliases in the `event-projector.ph
     ],
 ```
 
-With this configuration, instead of saving `\App\Events\MoneyAddedEvent` in the database, we just store `money_added`, now you can change the event classname and namespace. Just make sure to also change the mapping!
+With this configuration, instead of saving `\App\Events\MoneyAddedEvent` in the database, we just store `money_added`, now you can change the event class name and namespace. Just make sure to also change the mapping!

--- a/docs/getting-familiar-with-event-sourcing/introduction.md
+++ b/docs/getting-familiar-with-event-sourcing/introduction.md
@@ -9,9 +9,9 @@ Event sourcing tries to solve this problem by storing all events that happen in 
 
 Here's a concrete example to make it more clear. Imagine you're a bank. Your clients have accounts. Storing the balance of the accounts wouldn't be enough; all the transactions should be remembered too. With event sourcing, the balance isn't a standalone database field, but a value calculated from the stored transactions.
 
-After taking a look at [an example of traditional application](/laravel-event-projector/v2/getting-familiar-with-event-sourcing/the-traditional-application), we're going to discuss the two concepts that make up this package: [projectors](/laravel-event-projector/v2/getting-familiar-with-event-sourcing/using-projectors-to-transform-events) and [aggregates](/laravel-event-projector/v2/getting-familiar-with-event-sourcing/using-aggregates-to-make-decisions-based-on-the-past).
+After taking a look at [an example of traditional application](/laravel-event-projector/v3/getting-familiar-with-event-sourcing/the-traditional-application), we're going to discuss the two concepts that make up this package: [projectors](/laravel-event-projector/v3/getting-familiar-with-event-sourcing/using-projectors-to-transform-events) and [aggregates](/laravel-event-projector/v3/getting-familiar-with-event-sourcing/using-aggregates-to-make-decisions-based-on-the-past).
 
-If you want to skip to reading code immediately, here are the Larabank example apps used in this section. In all of them, you can create accounts and deposit or withdraw money. 
+If you want to skip to reading code immediately, here are the Larabank example apps used in this section. In all of them, you can create accounts and deposit or withdraw money.
 
 - [Larabank built traditionally without event sourcing](https://github.com/spatie/larabank-traditional)
 - [Larabank built with projectors](https://github.com/spatie/larabank-event-projector)

--- a/docs/getting-familiar-with-event-sourcing/using-aggregates-to-make-decisions-based-on-the-past.md
+++ b/docs/getting-familiar-with-event-sourcing/using-aggregates-to-make-decisions-based-on-the-past.md
@@ -53,4 +53,4 @@ Whenever we retrieve an aggregate, all of the previously stored events will be f
 
 In summary, aggregates are used to make decisions based on past events.
 
-If you want to know how to create and use aggregates, head over to [the `using-aggregates` section](https://docs.spatie.be/laravel-event-projector/v2/using-aggregates/writing-your-first-aggregate).
+If you want to know how to create and use aggregates, head over to [the `using-aggregates` section](/laravel-event-projector/v3/using-aggregates/writing-your-first-aggregate).

--- a/docs/getting-familiar-with-event-sourcing/using-projectors-to-transform-events.md
+++ b/docs/getting-familiar-with-event-sourcing/using-projectors-to-transform-events.md
@@ -3,7 +3,7 @@ title: Using projectors to transform events
 weight: 3
 ---
 
-Let's build a bit further on the [Larabank example](https://github.com/spatie/larabank-traditional) mentioned in [the previous section](https://docs.spatie.be/laravel-event-projector/v2/getting-familiar-with-event-sourcing/the-traditional-application). The main drawback highlighted that example is the fact that when updating a value, we lose the old value. Let's solve that problem.
+Let's build a bit further on the [Larabank example](https://github.com/spatie/larabank-traditional) mentioned in [the previous section](/laravel-event-projector/v3/getting-familiar-with-event-sourcing/the-traditional-application). The main drawback highlighted that example is the fact that when updating a value, we lose the old value. Let's solve that problem.
 
 Instead of directly updating the value in the database, we could write every change we want to make as an event in our database.
 
@@ -37,4 +37,4 @@ This package can help you store native Laravel events in a `stored_events` table
 
 Here's our example app [Larabank rebuild with projectors](https://github.com/spatie/larabank-event-projector). In [the `AccountsController`](https://github.com/spatie/larabank-event-projector/blob/d02fd1de7f31f4b915c05df79d9ba61440f9e6b5/app/Http/Controllers/AccountsController.php#L20-L36) we're not going to directly modify the database anymore. Instead, the controller will call methods which will in [their turn fire off events](https://github.com/spatie/larabank-event-projector/blob/master/app/Account.php#L15-L42). Our package will listen for those events (which implement the empty `ShouldBeStored` interface) and store them in the `stored_events` table. Those events will also get passed to [all registered projectors](https://github.com/spatie/larabank-event-projector/blob/d02fd1de7f31f4b915c05df79d9ba61440f9e6b5/config/event-projector.php#L14). The [`AccountsProjector`](https://github.com/spatie/larabank-event-projector/blob/d02fd1de7f31f4b915c05df79d9ba61440f9e6b5/app/Projectors/AccountsProjector.php) will build the `Accounts` table using [a couple of events it listens for](https://github.com/spatie/larabank-event-projector/blob/d02fd1de7f31f4b915c05df79d9ba61440f9e6b5/app/Projectors/AccountsProjector.php#L17-L22).
 
-If you want to know more about projectors and how to use them, head over to [the `using-projectors` section](https://docs.spatie.be/laravel-event-projector/v2/using-projectors/writing-your-first-projector).
+If you want to know more about projectors and how to use them, head over to [the `using-projectors` section](/laravel-event-projector/v3/using-projectors/writing-your-first-projector).

--- a/docs/installation-setup.md
+++ b/docs/installation-setup.md
@@ -104,7 +104,7 @@ return [
     /*
      * In production, you likely don't want the package to auto discover the event handlers
      * on every request. The package can cache all registered event handlers.
-     * More info: https://docs.spatie.be/laravel-event-projector/v2/advanced-usage/discovering-projectors-and-reactors
+     * More info: https://docs.spatie.be/laravel-event-projector/v3/advanced-usage/discovering-projectors-and-reactors
      *
      * Here you can specify where the cache should be stored.
      */
@@ -112,6 +112,6 @@ return [
 ];
 ```
 
-The package will scan all classes of your project to [automatically discover projectors and reactors](/laravel-event-projector/v2/advanced-usage/discovering-projectors-and-reactors#discovering-projectors-and-reactors). In a production environment you probably should [cache auto discovered projectors and reactors](/laravel-event-projector/v2/advanced-usage/discovering-projectors-and-reactors#caching-discovered-projectors-and-reactors).
+The package will scan all classes of your project to [automatically discover projectors and reactors](/laravel-event-projector/v3/advanced-usage/discovering-projectors-and-reactors#discovering-projectors-and-reactors). In a production environment you probably should [cache auto discovered projectors and reactors](/laravel-event-projector/v3/advanced-usage/discovering-projectors-and-reactors#caching-discovered-projectors-and-reactors).
 
 It's recommended that should set up a queue. Specify the connection name in the `queue` key of the `event-projector` config file. This queue will be used to guarantee that the events will be processed by all projectors in the right order. You should make sure that the queue will process only one job at a time. In a local environment, where events have a very low chance of getting fired concurrently, it's probably ok to just use the `sync` driver.

--- a/docs/installation-setup.md
+++ b/docs/installation-setup.md
@@ -37,7 +37,7 @@ return [
 
     /*
      * Projectors are classes that build up projections. You can create them by performing
-     * `php artisan event-projector:create-projector`.  When not using autodiscovery
+     * `php artisan event-projector:create-projector`.  When not using auto-discovery
      * Projectors can be registered in this array or a service provider.
      */
     'projectors' => [
@@ -46,7 +46,7 @@ return [
 
     /*
      * Reactors are classes that handle side effects. You can create them by performing
-     * `php artisan event-projector:create-reactor`. When not using autodiscovery
+     * `php artisan event-projector:create-reactor`. When not using auto-discovery
      * Reactors can be registered in this array or a service provider.
      */
     'reactors' => [
@@ -79,7 +79,7 @@ return [
      * it should extend \Spatie\EventProjector\HandleDomainEventJob.
      */
     'stored_event_job' => \Spatie\EventProjector\HandleStoredEventJob::class,
-    
+
     /*
      * Similar to Relation::morphMap() you can define which alias responds to which
      * event class. This allows you to change the namespace or classnames

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -3,9 +3,9 @@ title: Introduction
 weight: 1
 ---
 
-This package aims to be the entry point to get started with event sourcing in Laravel. It can help you setting up aggregates, projectors and reactors. 
+This package aims to be the entry point to get started with event sourcing in Laravel. It can help you setting up aggregates, projectors and reactors.
 
-If you've never worked with event sourcing, or are uncertain about what projectors, reactors and aggregates are, head over to [the getting familiar with event sourcing section](https://docs.spatie.be/laravel-event-projector/v2/getting-familiar-with-event-sourcing/introduction).
+If you've never worked with event sourcing, or are uncertain about what projectors, reactors and aggregates are, head over to [the getting familiar with event sourcing section](/laravel-event-projector/v3/getting-familiar-with-event-sourcing/introduction).
 
 Are you visual learner? Then start by watching this video. It explains event sourcing in general and how you can use projectors, reactors and aggregates.
 

--- a/docs/using-aggregates/creating-and-configuring-aggregates.md
+++ b/docs/using-aggregates/creating-and-configuring-aggregates.md
@@ -5,8 +5,8 @@ weight: 2
 
 An aggregate is a class that decides to record events based on past events.
 
-## Creating an aggregate 
- 
+## Creating an aggregate
+
 The easiest way to create an aggregate root would be to use the `make:aggregate` command:
 
 ```php
@@ -78,7 +78,7 @@ To persist an aggregate call `persist` on it. Here's an example:
 ```php
 MyAggregate::retrieve($uuid) // will cause all events for this uuid to be fed to the `apply*` methods
    // call methods that record events
-   ->persist(); // 
+   ->persist(); //
 ```
 
 Persisting an aggregate root will write all newly recorded events to the database. The newly persisted events will get passed to all projectors and reactors.

--- a/docs/using-aggregates/writing-your-first-aggregate.md
+++ b/docs/using-aggregates/writing-your-first-aggregate.md
@@ -3,7 +3,7 @@ title: Writing your first aggregate
 weight: 1
 ---
 
-An aggregate is a class that decides to record events based on past events. To know more about their general purpose and the idea behind them, read this section on [using aggregates to make decisions-based-on-the-past](https://docs.spatie.be/laravel-event-projector/v2/getting-familiar-with-event-sourcing/using-aggregates-to-make-decisions-based-on-the-past).
+An aggregate is a class that decides to record events based on past events. To know more about their general purpose and the idea behind them, read this section on [using aggregates to make decisions-based-on-the-past](/laravel-event-projector/v3/getting-familiar-with-event-sourcing/using-aggregates-to-make-decisions-based-on-the-past).
 
 ## Creating an aggregate
 

--- a/docs/using-aggregates/writing-your-first-aggregate.md
+++ b/docs/using-aggregates/writing-your-first-aggregate.md
@@ -4,9 +4,9 @@ weight: 1
 ---
 
 An aggregate is a class that decides to record events based on past events. To know more about their general purpose and the idea behind them, read this section on [using aggregates to make decisions-based-on-the-past](https://docs.spatie.be/laravel-event-projector/v2/getting-familiar-with-event-sourcing/using-aggregates-to-make-decisions-based-on-the-past).
- 
-## Creating an aggregate 
- 
+
+## Creating an aggregate
+
 The easiest way to create an aggregate root would be to use the `make:aggregate` command:
 
 ```php
@@ -28,7 +28,7 @@ final class AccountAggregate extends AggregateRoot
 
 ## Recording events
 
-You can add any methods or variables you need on the aggregate. To get you familiar with event modeling using aggregates let's implement a small piece of [the Larabank example app](https://github.com/spatie/larabank-event-projector-aggregates). We are going to add methods to record the [`AccountCreated`](https://github.com/spatie/larabank-event-projector-aggregates/blob/master/app/Domain/Account/Events/AccountCreated.php), [`MoneyAdded`](https://github.com/spatie/larabank-event-projector-aggregates/blob/master/app/Domain/Account/Events/MoneyAdded.php) and the [`MoneySubtracted`](https://github.com/spatie/larabank-event-projector-aggregates/blob/master/app/Domain/Account/Events/MoneySubtracted.php) events.
+You can add any methods or variables you need on the aggregate. To get you familiar with event modelling using aggregates let's implement a small piece of [the Larabank example app](https://github.com/spatie/larabank-event-projector-aggregates). We are going to add methods to record the [`AccountCreated`](https://github.com/spatie/larabank-event-projector-aggregates/blob/master/app/Domain/Account/Events/AccountCreated.php), [`MoneyAdded`](https://github.com/spatie/larabank-event-projector-aggregates/blob/master/app/Domain/Account/Events/MoneyAdded.php) and the [`MoneySubtracted`](https://github.com/spatie/larabank-event-projector-aggregates/blob/master/app/Domain/Account/Events/MoneySubtracted.php) events.
 
 First, let's add a `createAccount` methods to our aggregate that will record the `AccountCreated` event.
 
@@ -44,12 +44,12 @@ final class AccountAggregate extends AggregateRoot
     {
         $this->recordThat(new AccountCreated($name, $userId));
     }
-    
+
     public function addMoney(int $amount)
     {
         $this->recordThat(new MoneyAdded($amount));
     }
-    
+
     public function subtractAmount(int $amount)
     {
         $this->recordThat(new MoneySubtracted($amount));
@@ -91,10 +91,10 @@ In our demo app we retrieve and persist the aggregate [in the `AccountsControlle
 
 Let's now implement the rule that an account cannot go below -$5000. Here's the thing to keep in mind: when retrieving an aggregate all events for the given uuid will be retrieved and will be passed to methods named `apply<className>` on the aggregate.
 
-So for our aggregate to receive all past `MoneyAdded` and `MoneySubtracted` events we need to add `applyMoneySubtracted` and`applyMoneySubtracted` methods to our aggregate. Because those events are all fed to the same instance of the aggregate, we can simply add an instance variable to hold the calculated balance. 
+So for our aggregate to receive all past `MoneyAdded` and `MoneySubtracted` events we need to add `applyMoneySubtracted` and`applyMoneySubtracted` methods to our aggregate. Because those events are all fed to the same instance of the aggregate, we can simply add an instance variable to hold the calculated balance.
 
 ```php
-// in our aggregate 
+// in our aggregate
 
 private $balance = 0;
 
@@ -138,10 +138,10 @@ public function subtractAmount(int $amount)
 {
     if (! $this->hasSufficientFundsToSubtractAmount($amount) {
         $this->recordThat(new AccountLimitHit($amount));
-        
+
         // persist the aggregate so the record event gets persisted
         $this->persist();
-    
+
         throw CouldNotSubtractMoney::notEnoughFunds($amount);
     }
 
@@ -164,14 +164,14 @@ public function subtractAmount(int $amount)
 {
     if (! $this->hasSufficientFundsToSubtractAmount($amount) {
         $this->recordThat(new AccountLimitHit($amount));
-        
+
         if ($this->accountLimitHitCount === 3) {
             $this->recordThat(new LoanProposed());
         }
-        
+
         // persist the aggregate so the record events gets persisted
         $this->persist();
-    
+
         throw CouldNotSubtractMoney::notEnoughFunds($amount);
     }
 

--- a/docs/using-projectors/creating-and-configuring-projectors.md
+++ b/docs/using-projectors/creating-and-configuring-projectors.md
@@ -69,7 +69,7 @@ Just by adding a typehint of the event you want to handle makes our package call
 
 ## Getting the uuid of an event
 
-In most cases you want to have access to the event that was fired. When [using aggregates](/laravel-event-projector/v2/using-aggregates/writing-your-first-aggregate) your events probably won't contain the uuid associated with that event. To get to the uuid of an event simply add a parameter called `$aggregateUuid` that typehinted as a string.
+In most cases you want to have access to the event that was fired. When [using aggregates](/laravel-event-projector/v3/using-aggregates/writing-your-first-aggregate) your events probably won't contain the uuid associated with that event. To get to the uuid of an event simply add a parameter called `$aggregateUuid` that typehinted as a string.
 
 ```php
 // ...

--- a/docs/using-projectors/creating-and-configuring-projectors.md
+++ b/docs/using-projectors/creating-and-configuring-projectors.md
@@ -69,7 +69,7 @@ Just by adding a typehint of the event you want to handle makes our package call
 
 ## Getting the uuid of an event
 
-In most cases you want to have access to the event that was fired. When [using aggregates](/laravel-event-projector/v2/using-aggregates/writing-your-first-aggregate) your events probably won't contain the uuid associated with that event. To get to the uuid of an event simply add a parameter called `$aggregateUuid` that typehinted as a string. 
+In most cases you want to have access to the event that was fired. When [using aggregates](/laravel-event-projector/v2/using-aggregates/writing-your-first-aggregate) your events probably won't contain the uuid associated with that event. To get to the uuid of an event simply add a parameter called `$aggregateUuid` that typehinted as a string.
 
 ```php
 // ...
@@ -77,9 +77,9 @@ In most cases you want to have access to the event that was fired. When [using a
 public function onMoneyAdded(MoneyAdded $event, string $aggregateUuid)
 {
     $account = Account::findByUuid($aggregateUuid);
-    
+
     $account->balance += $event->amount;
-    
+
     $account->save();
 }
 ```
@@ -132,7 +132,7 @@ Instead of letting a method on a projector handle an event you can use a dedicat
 protected $handlesEvents = [
     /*
      * If this event is passed to the projector, the `AddMoneyToAccount` class will be called.
-     */ 
+     */
     MoneyAdded::class => AddMoneyToAccount::class,
 ];
 ```
@@ -175,7 +175,7 @@ You can write this a little shorter. Just put the class name of an event in that
 protected $handlesEvents = [
     /*
      * If this event is passed to the projector, the `onMoneyAdded` method will be called.
-     */ 
+     */
     MoneyAdded::class,
 ];
 ```

--- a/docs/using-projectors/thinking-in-events.md
+++ b/docs/using-projectors/thinking-in-events.md
@@ -3,9 +3,9 @@ title: Thinking in events
 weight: 5
 ---
 
-In this example we're going to try to send a mail whenever an account is broke (balance below zero). You can do this with projectors and reactors alone, but aggregates might be a better fit for this. Aggregates make it easy to make decisions based on past events. Check out the section on [how to use aggreates](https://docs.spatie.be/laravel-event-projector/v2/introduction) to learn more about them, or keep reading on this page if you don't want to use aggragetes.
+In this example we're going to try to send a mail whenever an account is broke (balance below zero). You can do this with projectors and reactors alone, but aggregates might be a better fit for this. Aggregates make it easy to make decisions based on past events. Check out the section on [how to use aggregates](https://docs.spatie.be/laravel-event-projector/v2/introduction) to learn more about them, or keep reading on this page if you don't want to use aggregates.
 
-Let's build upon the examples shown in the [writing your first projector](/laravel-event-projector/v2/using-projectors/writing-your-first-projector) and [handling side effects with reactors](https://docs.spatie.be/laravel-event-projector/v2/using-reactors/writing-your-first-reactor)' sections. 
+Let's build upon the examples shown in the [writing your first projector](/laravel-event-projector/v2/using-projectors/writing-your-first-projector) and [handling side effects with reactors](https://docs.spatie.be/laravel-event-projector/v2/using-reactors/writing-your-first-reactor)' sections.
 
 Imagine you are tasked with sending a mail to an account holder whenever he or she is broke. You might think, that's easy, let's just check in a new reactor if the account balance is less than zero.
 
@@ -92,7 +92,7 @@ class BrokeReactor implements EventHandler
 }
 ```
 
-Let's leverage that new event in the `AccountBalanceProjector`. 
+Let's leverage that new event in the `AccountBalanceProjector`.
 
 ```php
 // ...
@@ -107,7 +107,7 @@ class AccountBalanceProjector implements Projector
 
         $account->save();
     }
-    
+
     public function onMoneyAdded(MoneyAdded $event)
     {
         $account = Account::uuid($event->accountUuid);

--- a/docs/using-projectors/thinking-in-events.md
+++ b/docs/using-projectors/thinking-in-events.md
@@ -3,9 +3,9 @@ title: Thinking in events
 weight: 5
 ---
 
-In this example we're going to try to send a mail whenever an account is broke (balance below zero). You can do this with projectors and reactors alone, but aggregates might be a better fit for this. Aggregates make it easy to make decisions based on past events. Check out the section on [how to use aggregates](https://docs.spatie.be/laravel-event-projector/v2/introduction) to learn more about them, or keep reading on this page if you don't want to use aggregates.
+In this example we're going to try to send a mail whenever an account is broke (balance below zero). You can do this with projectors and reactors alone, but aggregates might be a better fit for this. Aggregates make it easy to make decisions based on past events. Check out the section on [how to use aggregates](/laravel-event-projector/v3/introduction) to learn more about them, or keep reading on this page if you don't want to use aggregates.
 
-Let's build upon the examples shown in the [writing your first projector](/laravel-event-projector/v2/using-projectors/writing-your-first-projector) and [handling side effects with reactors](https://docs.spatie.be/laravel-event-projector/v2/using-reactors/writing-your-first-reactor)' sections.
+Let's build upon the examples shown in the [writing your first projector](/laravel-event-projector/v3/using-projectors/writing-your-first-projector) and [handling side effects with reactors](/laravel-event-projector/v3/using-reactors/writing-your-first-reactor)' sections.
 
 Imagine you are tasked with sending a mail to an account holder whenever he or she is broke. You might think, that's easy, let's just check in a new reactor if the account balance is less than zero.
 

--- a/docs/using-projectors/writing-your-first-projector.md
+++ b/docs/using-projectors/writing-your-first-projector.md
@@ -3,7 +3,7 @@ title: Writing your first projector
 weight: 1
 ---
 
-This section is a perfect entry point to get yourself aquinted with projectors. Most examples in these docs are also available in the Laravel app you'll find in [this repo on GitHub](https://github.com/spatie/larabank-event-projector). Clone that repo to toy around with the package.
+This section is a perfect entry point to get yourself acquainted with projectors. Most examples in these docs are also available in the Laravel app you'll find in [this repo on GitHub](https://github.com/spatie/larabank-event-projector). Clone that repo to toy around with the package.
 
 A projector is a class that gets triggered when new events come in. It typically writes data (to the database or to a file on disk). We call that written data a projection.
 
@@ -56,7 +56,7 @@ class Account extends Model
     public static function createWithAttributes(array $attributes): Account
     {
         /*
-         * Let's generate a uuid. 
+         * Let's generate a uuid.
          */
         $attributes['uuid'] = (string) Uuid::uuid4();
 

--- a/docs/using-reactors/writing-your-first-reactor.md
+++ b/docs/using-reactors/writing-your-first-reactor.md
@@ -5,7 +5,7 @@ weight: 1
 
 ## What is a reactor
 
-Now that you've [written your first projector](/laravel-event-projector/v2/using-projectors/writing-your-first-projector), let's learn how to handle side effects. With side effects we mean things like sending a mail, sending a notification, ... You only want to perform these actions when the original event happens. You don't want to do this work when replaying events.
+Now that you've [written your first projector](/laravel-event-projector/v3/using-projectors/writing-your-first-projector), let's learn how to handle side effects. With side effects we mean things like sending a mail, sending a notification, ... You only want to perform these actions when the original event happens. You don't want to do this work when replaying events.
 
 A reactor is a class, that much like a projector, listens for incoming events. Unlike projectors however, reactors will not get called when events are replayed. Reactors only will get called when the original event fires.
 
@@ -26,7 +26,7 @@ use Spatie\EventProjector\EventHandlers\HandlesEvents;
 final class BigAmountAddedReactor implements EventHandler
 {
     use HandlesEvents;
-    
+
     public function onMoneyAdded(MoneyAdded $event)
     {
         if ($event->amount < 900) {


### PR DESCRIPTION
A while ago, in #131, I said I'd add the docs for the function: `Projectionist::withoutEventHandler($class)`.

Here it is! I also included some typo fixes and link updates for the v3 docs.