### PR TITLE
[3.x] Revert to using laravel-schemaless-attributes for meta_data

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,6 +27,7 @@
         "illuminate/events": "^6.0",
         "illuminate/support": "^6.0",
         "league/flysystem": "^1.0.45",
+        "spatie/laravel-schemaless-attributes": "^1.6",
         "symfony/finder": "^4.2",
         "symfony/property-access": "^4.0",
         "symfony/serializer": "^4.0"

--- a/src/Models/EloquentStoredEvent.php
+++ b/src/Models/EloquentStoredEvent.php
@@ -6,6 +6,7 @@ use Spatie\EventProjector\StoredEvent;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Builder;
 use Spatie\EventProjector\ShouldBeStored;
+use Spatie\SchemalessAttributes\SchemalessAttributes;
 
 class EloquentStoredEvent extends Model
 {
@@ -35,6 +36,16 @@ class EloquentStoredEvent extends Model
     public function getEventAttribute(): ShouldBeStored
     {
         return $this->toStoredEvent()->event;
+    }
+
+    public function getMetaDataAttribute(): SchemalessAttributes
+    {
+        return SchemalessAttributes::createForModel($this, 'meta_data');
+    }
+
+    public function scopeWithMetaDataAttributes(): Builder
+    {
+        return SchemalessAttributes::scopeWithSchemalessAttributes('meta_data');
     }
 
     public function scopeStartingFrom(Builder $query, int $storedEventId): void

--- a/tests/Models/StoredEventTest.php
+++ b/tests/Models/StoredEventTest.php
@@ -58,6 +58,29 @@ final class StoredEventTest extends TestCase
         $this->assertDatabaseHas('stored_events', ['event_class' => 'money_added']);
     }
 
+    /** @test * */
+    public function it_allows_to_modify_metadata_with_offset_set_in_eloquent_model()
+    {
+        EloquentStoredEvent::creating(function (EloquentStoredEvent $event) {
+            $event->meta_data['ip'] = '127.0.0.1';
+        });
+
+        $this->setConfig('event-projector.event_class_map', [
+            'money_added' => MoneyAddedEvent::class,
+        ]);
+
+        $this->fireEvents();
+
+        $instance = EloquentStoredEvent::first();
+        $payload = (new EloquentStoredEvent())->getConnection()->raw("CAST('{\"ip\": \"127.0.0.1\"}' AS JSON)");
+
+        $this->assertArrayHasKey('ip', $instance->meta_data->toArray());
+        $this->assertSame('127.0.0.1', $instance->meta_data['ip']);
+        $this->assertDatabaseHas('stored_events', ['meta_data' => $payload]);
+
+        EloquentStoredEvent::flushEventListeners();
+    }
+
     public function fireEvents(int $number = 1, string $className = MoneyAddedEvent::class)
     {
         foreach (range(1, $number) as $i) {

--- a/tests/Models/StoredEventTest.php
+++ b/tests/Models/StoredEventTest.php
@@ -71,12 +71,11 @@ final class StoredEventTest extends TestCase
 
         $this->fireEvents();
 
-        $instance = EloquentStoredEvent::first();
-        $payload = (new EloquentStoredEvent())->getConnection()->raw("CAST('{\"ip\": \"127.0.0.1\"}' AS JSON)");
+        $instance = EloquentStoredEvent::withMetaDataAttributes('ip', '127.0.0.1')->first();
 
+        $this->assertInstanceOf(EloquentStoredEvent::class, $instance);
         $this->assertArrayHasKey('ip', $instance->meta_data->toArray());
         $this->assertSame('127.0.0.1', $instance->meta_data['ip']);
-        $this->assertDatabaseHas('stored_events', ['meta_data' => $payload]);
 
         EloquentStoredEvent::flushEventListeners();
     }


### PR DESCRIPTION
In the version 3.x of `laravel-event-projector` the `laravel-schemaless-attributes` dependency was removed.

That dependency allowed us to use the following syntax to update an `EloquentStoredEvent`'s `meta_data` attribute:

~~~php
$event->meta_data['ip'] = '127.0.0.1';
~~~

This syntax is the one outlined in this package documentation.

With the dependency removal this syntax no longer works and an `ErrorException: Indirect modification of overloaded property` is thrown when trying to set a key in the `meta_data` property using the above notation.

This error is due that attributes from an Eloquent Model are retrieved due through the `__get` magic method and not accessed directly. This is a PHP limitation as it returns a copy of the value instead of a reference to the underlying array.

When using the `laravel-schemaless-attributes` package an instance of the `SchemalessAttributes` class was returned which implements the `ArrayAccess` interface. As objects are returned by reference, the syntax in the snippet above works as expected.

One workaround is to use the following syntax:

~~~php
$event->meta_data = ['ip' => '127.0.0.1'];
~~~

This will pass a new array to the `__set` magic method on the `EloquentStoredEvent` model and it will replace the underlying `meta_data` attribute.

The downside is if you have multiple places (listeners for example) that can modify the `meta_data` property. The user should keep track of the previous value to prevent overriding the whole array and loosing previous changes.

I added a test to make sure the documented syntax works. I appreciate if you can review the tests where I have two doubts:

1. ~I needed to use a database raw cast to JSON to compare against the `meta_data` column in the database~
2. I added a `EloquentStoredEvent::flushEventListeners();` to the end of the test, not sure if that is needed.

I will happily make any changes to improve this test

**EDIT** I removed the MySQL specific syntax due to tests failing with PostgreSQL

---

**Epilogue**

**The tests already have a test against manipulating an event's meta_data property, why this PR is needed?**

Indeed there are already two tests that test against an event's `meta_data` modification, but those tests assert against the new `StoredEvent` class which is a wrapper around the `EloquentStoredEvent`.

In this new class the `meta_data` is a first-party property, so it is not accessed through the `__get` magic method, thus the modification through the offset set syntax is allowed.

