### PR TITLE
Change default cache path

### DIFF
--- a/config/event-projector.php
+++ b/config/event-projector.php
@@ -90,5 +90,5 @@ return [
      *
      * Here you can specify where the cache should be stored.
      */
-    'cache_path' => storage_path('app/event-projector'),
+    'cache_path' => base_path('bootstrap/cache'),
 ];


### PR DESCRIPTION
Wanted to suggest changing the default cache path to where the Laravel framework places its cache files: `./bootstrap/cache/`